### PR TITLE
Set the Retry-After header, per RFC 6585, when returning a 429

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -103,6 +103,7 @@ func (l *rateLimiter) Handler(next http.Handler) http.Handler {
 		}
 
 		if nrate >= l.requestLimit {
+			w.Header().Set("Retry-After", fmt.Sprintf("%d", int(l.windowLength.Seconds()))) // RFC 6585
 			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 			return
 		}


### PR DESCRIPTION
This allows services using httprate to work with http clients that expect the [standard Retry-After header described in RFC 6585](https://tools.ietf.org/html/rfc6585#section-4), such as hashicorp/go-retryablehttp's [DefaultBackoff](https://pkg.go.dev/github.com/hashicorp/go-retryablehttp#DefaultBackoff) and [curl 7.66+](https://github.com/go-chi/httprate/pull/3#issue-550372927).

Retry-After is always set to l.windowLength, rather than the seconds remaining till the end of the current window, to reduce the likelihood of creating thundering hurds at window intervals. I don't have a strong opinion about that and would be happy to change it.