### PR TITLE
Make it possible to dynamically disable the rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,16 @@ func main() {
   r.Use(httprate.Limit(
     100,           // requests
     1*time.Minute, // per duration
-    // an oversimplified example of rate limiting by a custom header
     httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
-    	return r.Header.Get("X-Access-Token"), nil
+      // disable rate limiting for all private ips
+      ipStr, _, _ := net.SplitHostPort(r.RemoteAddr)
+      ip := net.ParseIP(ipStr)
+      if ip.IsPrivate() {
+        return "", httprate.NoRateLimit
+      }
+
+      // an oversimplified example of rate limiting by a custom header
+      return r.Header.Get("X-Access-Token"), nil
     }),
   ))
 ```

--- a/httprate.go
+++ b/httprate.go
@@ -1,6 +1,7 @@
 package httprate
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"strings"
@@ -49,6 +50,8 @@ func KeyByIP(r *http.Request) (string, error) {
 func KeyByEndpoint(r *http.Request) (string, error) {
 	return r.URL.Path, nil
 }
+
+var NoRateLimit = errors.New("use this to signal that the rate limit should be ignored")
 
 func WithKeyFuncs(keyFuncs ...KeyFunc) Option {
 	return func(rl *rateLimiter) {

--- a/limiter.go
+++ b/limiter.go
@@ -92,6 +92,10 @@ func (r *rateLimiter) Status(key string) (bool, float64, error) {
 func (l *rateLimiter) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key, err := l.keyFn(r)
+		if err == NoRateLimit {
+			next.ServeHTTP(w, r)
+			return
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusPreconditionRequired)
 			return


### PR DESCRIPTION
Hi,
this pull request adds the possibility to dynamically disable the rate limiting. For example to allow requests from specific ip ranges without rate limiting them.

It is implemented via a special error `httprate.NoRateLimit` which custom key functions can return to signal that the rate limit handler should be skipped.

You can find an example in the [README.md](https://github.com/ydylla/httprate/commit/e6da25f7bdd95b9da231d9030d302d3ba193fa93)

I hope you like it 😃 