### PR TITLE
Block by IPv6 /64 rather than individual addresses

### DIFF
--- a/httprate.go
+++ b/httprate.go
@@ -43,7 +43,7 @@ func KeyByIP(r *http.Request) (string, error) {
 		}
 	}
 
-	return ip, nil
+	return canonicalizeIP(ip), nil
 }
 
 func KeyByEndpoint(r *http.Request) (string, error) {
@@ -82,4 +82,51 @@ func composedKeyFunc(keyFuncs ...KeyFunc) KeyFunc {
 		}
 		return key.String(), nil
 	}
+}
+
+// CanonicalizeIP returns a form of ip suitable for comparison to other IPs.
+// For IPv4 addresses, this is simply the whole string.
+// For IPv6 addresses, this is the /64 prefix.
+func canonicalizeIP(ip string) string {
+	isIPv6 := false
+	// This is how net.ParseIP decides if an address is IPv6
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/net/ip.go;l=704
+	for i := 0; !isIPv6 && i < len(ip); i++ {
+		switch ip[i] {
+		case '.':
+			// IPv4
+			return ip
+		case ':':
+			// IPv6
+			isIPv6 = true
+			break
+		}
+	}
+	if !isIPv6 {
+		// Not an IP address at all
+		return ip
+	}
+
+	// By default, the string representation of a net.IPNet (masked IP address) is just
+	// "full_address/mask_bits". But using that will result in different addresses with
+	// the same /64 prefix comparing differently. So we need to zero out the last 64 bits
+	// so that all IPs in the same prefix will be the same.
+	//
+	// Note: When 1.18 is the minimum Go version, this can be written more cleanly like:
+	// netip.PrefixFrom(netip.MustParseAddr(ipv6), 64).Masked().Addr().String()
+	// (With appropriate error checking.)
+
+	ipv6 := net.ParseIP(ip)
+	if ipv6 == nil {
+		return ip
+	}
+
+	const bytesToZero = (128 - 64) / 8
+	for i := len(ipv6) - bytesToZero; i < len(ipv6); i++ {
+		ipv6[i] = 0
+	}
+
+	// Note that this doesn't have the "/64" suffix customary with a CIDR representation,
+	// but those three bytes add nothing for us.
+	return ipv6.String()
 }

--- a/httprate_test.go
+++ b/httprate_test.go
@@ -1,0 +1,59 @@
+package httprate
+
+import "testing"
+
+func Test_canonicalizeIP(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want string
+	}{
+		{
+			name: "IPv4 unchanged",
+			ip:   "1.2.3.4",
+			want: "1.2.3.4",
+		},
+		{
+			name: "bad IP unchanged",
+			ip:   "not an IP",
+			want: "not an IP",
+		},
+		{
+			name: "bad IPv6 unchanged",
+			ip:   "not:an:IP",
+			want: "not:an:IP",
+		},
+		{
+			name: "empty string unchanged",
+			ip:   "",
+			want: "",
+		},
+		{
+			name: "IPv6 test 1",
+			ip:   "2001:DB8::21f:5bff:febf:ce22:8a2e",
+			want: "2001:db8:0:21f::",
+		},
+		{
+			name: "IPv6 test 2",
+			ip:   "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			want: "2001:db8:85a3::",
+		},
+		{
+			name: "IPv6 test 3",
+			ip:   "fe80::1ff:fe23:4567:890a",
+			want: "fe80::",
+		},
+		{
+			name: "IPv6 test 4",
+			ip:   "f:f:f:f:f:f:f:f",
+			want: "f:f:f:f::",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalizeIP(tt.ip); got != tt.want {
+				t.Errorf("canonicalizeIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -142,6 +142,13 @@ func TestLimitIP(t *testing.T) {
 			reqIp:         []string{"1.1.1.1:100", "1.1.1.1:100", "2.2.2.2:200"},
 			respCodes:     []int{200, 429, 200},
 		},
+		{
+			name:          "block-ipv6",
+			requestsLimit: 1,
+			windowLength:  2 * time.Second,
+			reqIp:         []string{"2001:DB8::21f:5bff:febf:ce22:1111", "2001:DB8::21f:5bff:febf:ce22:2222", "2002:DB8::21f:5bff:febf:ce22:1111"},
+			respCodes:     []int{200, 429, 200},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Right now httprate handles IPv6 addresses the same as IPv4 -- it blocks individual addresses. But the _smallest_ assignment a home user can get is a /64 prefix (2^64 addresses), and it's common to get a /56 or even a /48 (2^72 and 2^80 addresses, respectively). (ref: [RIPE](https://www.ripe.net/publications/docs/ripe-690), [RFC 6177](https://datatracker.ietf.org/doc/html/rfc6177))

Because there's no size limit on the rate limiting cache in tollbooth, that means that a single home-user-attacker could blow up the memory of a server using httprate. (And size-limiting by itself is no good, because any size limit less than 2^64 means that a single attacker could just cycle IPs and never be blocked.)

Blocking /64 prefixes is also what [Cloudflare](https://support.cloudflare.com/hc/en-us/articles/115001635128-Configuring-Cloudflare-Rate-Limiting) and [Nextcloud](https://hackerone.com/reports/1154003) do. (There are [more complex possible approaches](https://serverfault.com/a/863511/476142).)

(I wrote a blog post about this IPv6 rate-limiting stuff but then decided I'd better PR fixes before publishing it. But if you want a lot more detail: https://gist.github.com/adam-p/900f0d96882e59c891825bbeb53d5589)

Note that I'm submitting a similar PR with similar code to https://github.com/didip/tollbooth