### PR TITLE
Allows limiter headers to be written via setting instead of sending them at all times #15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-aegian/httprate
+module github.com/go-chi/httprate
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-chi/httprate
+module github.com/go-aegian/httprate
 
 go 1.14
 

--- a/httprate.go
+++ b/httprate.go
@@ -14,12 +14,12 @@ func Limit(requestLimit int, windowLength time.Duration, options ...Option) func
 type KeyFunc func(r *http.Request) (string, error)
 type Option func(rl *rateLimiter)
 
-func LimitAll(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
-	return Limit(requestLimit, windowLength)
+func LimitAll(requestLimit int, windowLength time.Duration, writeHeaders bool) func(next http.Handler) http.Handler {
+	return Limit(requestLimit, windowLength, WithHeaders(writeHeaders))
 }
 
-func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
-	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByIP))
+func LimitByIP(requestLimit int, windowLength time.Duration, writeHeaders bool) func(next http.Handler) http.Handler {
+	return Limit(requestLimit, windowLength, WithHeaders(writeHeaders), WithKeyFuncs(KeyByIP))
 }
 
 func KeyByIP(r *http.Request) (string, error) {
@@ -67,6 +67,12 @@ func WithLimitHandler(h http.HandlerFunc) Option {
 func WithLimitCounter(c LimitCounter) Option {
 	return func(rl *rateLimiter) {
 		rl.limitCounter = c
+	}
+}
+
+func WithHeaders(on bool) Option {
+	return func(rl *rateLimiter) {
+		rl.writeHeaders = on
 	}
 }
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-chi/httprate"
 )
 
+var LimiterHeaders = []string{"X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset", "Retry-After"}
+
 func TestLimit(t *testing.T) {
 	type test struct {
 		name          string
@@ -35,14 +37,66 @@ func TestLimit(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			router := httprate.LimitAll(tt.requestsLimit, tt.windowLength)(h)
+			router := httprate.LimitAll(tt.requestsLimit, tt.windowLength, true)(h)
 
 			for _, code := range tt.respCodes {
 				req := httptest.NewRequest("GET", "/", nil)
 				recorder := httptest.NewRecorder()
 				router.ServeHTTP(recorder, req)
-				if respCode := recorder.Result().StatusCode; respCode != code {
+
+				response := recorder.Result()
+
+				if respCode := response.StatusCode; respCode != code {
 					t.Errorf("resp.StatusCode(%v) = %v, want %v", i, respCode, code)
+				}
+			}
+		})
+	}
+}
+
+func TestLimitNoHeaders(t *testing.T) {
+	type test struct {
+		name          string
+		requestsLimit int
+		windowLength  time.Duration
+		respCodes     []int
+		headers       []string
+	}
+	tests := []test{
+		{
+			name:          "no-block",
+			requestsLimit: 3,
+			windowLength:  4 * time.Second,
+			respCodes:     []int{200, 200, 200},
+			headers:       LimiterHeaders,
+		},
+		{
+			name:          "block",
+			requestsLimit: 3,
+			windowLength:  2 * time.Second,
+			respCodes:     []int{200, 200, 200, 429},
+			headers:       LimiterHeaders,
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+			router := httprate.LimitAll(tt.requestsLimit, tt.windowLength, false)(h)
+
+			for _, code := range tt.respCodes {
+				req := httptest.NewRequest("GET", "/", nil)
+				recorder := httptest.NewRecorder()
+				router.ServeHTTP(recorder, req)
+				response := recorder.Result()
+
+				if respCode := response.StatusCode; respCode != code {
+					t.Errorf("resp.StatusCode(%v) = %v, want %v", i, respCode, code)
+				}
+
+				for _, header := range tt.headers {
+					if response.Header.Get(header) != "" {
+						t.Errorf("resp.Headers(%v) got %v wanted no header", i, header)
+					}
 				}
 			}
 		})
@@ -94,6 +148,7 @@ func TestLimitHandler(t *testing.T) {
 			router := httprate.Limit(
 				tt.requestsLimit,
 				tt.windowLength,
+				httprate.WithHeaders(true),
 				httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
 					http.Error(w, "Wow Slow Down Kiddo", 429)
 				}),
@@ -113,6 +168,86 @@ func TestLimitHandler(t *testing.T) {
 
 				if respBody != expected.Body {
 					t.Errorf("resp.Body(%v) = %v, want %v", i, respBody, expected.Body)
+				}
+			}
+		})
+	}
+}
+
+func TestLimitHandlerNoHeaders(t *testing.T) {
+	type test struct {
+		name          string
+		requestsLimit int
+		windowLength  time.Duration
+		responses     []struct {
+			Body       string
+			StatusCode int
+			Headers    []string
+		}
+	}
+	tests := []test{
+		{
+			name:          "no-block",
+			requestsLimit: 3,
+			windowLength:  4 * time.Second,
+			responses: []struct {
+				Body       string
+				StatusCode int
+				Headers    []string
+			}{
+				{Body: "", StatusCode: 200, Headers: LimiterHeaders},
+				{Body: "", StatusCode: 200, Headers: LimiterHeaders},
+				{Body: "", StatusCode: 200, Headers: LimiterHeaders},
+			},
+		},
+		{
+			name:          "block",
+			requestsLimit: 3,
+			windowLength:  2 * time.Second,
+			responses: []struct {
+				Body       string
+				StatusCode int
+				Headers    []string
+			}{
+				{Body: "", StatusCode: 200, Headers: LimiterHeaders},
+				{Body: "", StatusCode: 200, Headers: LimiterHeaders},
+				{Body: "", StatusCode: 200, Headers: LimiterHeaders},
+				{Body: "Wow Slow Down Kiddo", StatusCode: 429, Headers: LimiterHeaders},
+			},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+			router := httprate.Limit(
+				tt.requestsLimit,
+				tt.windowLength,
+				httprate.WithHeaders(false),
+				httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "Wow Slow Down Kiddo", 429)
+				}),
+			)(h)
+
+			for _, expected := range tt.responses {
+				req := httptest.NewRequest("GET", "/", nil)
+				recorder := httptest.NewRecorder()
+				router.ServeHTTP(recorder, req)
+				result := recorder.Result()
+				if respStatus := result.StatusCode; respStatus != expected.StatusCode {
+					t.Errorf("resp.StatusCode(%v) = %v, want %v", i, respStatus, expected.StatusCode)
+				}
+				buf := new(bytes.Buffer)
+				buf.ReadFrom(result.Body)
+				respBody := strings.TrimSuffix(buf.String(), "\n")
+
+				if respBody != expected.Body {
+					t.Errorf("resp.Body(%v) = %v, want %v", i, respBody, expected.Body)
+				}
+
+				for _, header := range expected.Headers {
+					if result.Header.Get(header) != "" {
+						t.Errorf("resp.Headers(%v) got %v wanted no header", i, header)
+					}
 				}
 			}
 		})
@@ -153,15 +288,80 @@ func TestLimitIP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			router := httprate.LimitByIP(tt.requestsLimit, tt.windowLength)(h)
+			router := httprate.LimitByIP(tt.requestsLimit, tt.windowLength, true)(h)
 
 			for i, code := range tt.respCodes {
 				req := httptest.NewRequest("GET", "/", nil)
 				req.RemoteAddr = tt.reqIp[i]
 				recorder := httptest.NewRecorder()
 				router.ServeHTTP(recorder, req)
-				if respCode := recorder.Result().StatusCode; respCode != code {
+
+				response := recorder.Result()
+
+				if respCode := response.StatusCode; respCode != code {
 					t.Errorf("resp.StatusCode(%v) = %v, want %v", i, respCode, code)
+				}
+			}
+		})
+	}
+}
+
+func TestLimitIPNoHeaders(t *testing.T) {
+	type test struct {
+		name          string
+		requestsLimit int
+		windowLength  time.Duration
+		reqIp         []string
+		respCodes     []int
+		headers       []string
+	}
+	tests := []test{
+		{
+			name:          "no-block",
+			requestsLimit: 3,
+			windowLength:  2 * time.Second,
+			reqIp:         []string{"1.1.1.1:100", "2.2.2.2:200"},
+			respCodes:     []int{200, 200},
+			headers:       LimiterHeaders,
+		},
+		{
+			name:          "block-ip",
+			requestsLimit: 1,
+			windowLength:  2 * time.Second,
+			reqIp:         []string{"1.1.1.1:100", "1.1.1.1:100", "2.2.2.2:200"},
+			respCodes:     []int{200, 429, 200},
+			headers:       LimiterHeaders,
+		},
+		{
+			name:          "block-ipv6",
+			requestsLimit: 1,
+			windowLength:  2 * time.Second,
+			reqIp:         []string{"2001:DB8::21f:5bff:febf:ce22:1111", "2001:DB8::21f:5bff:febf:ce22:2222", "2002:DB8::21f:5bff:febf:ce22:1111"},
+			respCodes:     []int{200, 429, 200},
+			headers:       LimiterHeaders,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+			router := httprate.LimitByIP(tt.requestsLimit, tt.windowLength, false)(h)
+
+			for i, code := range tt.respCodes {
+				req := httptest.NewRequest("GET", "/", nil)
+				req.RemoteAddr = tt.reqIp[i]
+				recorder := httptest.NewRecorder()
+				router.ServeHTTP(recorder, req)
+
+				response := recorder.Result()
+
+				if respCode := response.StatusCode; respCode != code {
+					t.Errorf("resp.StatusCode(%v) = %v, want %v", i, respCode, code)
+				}
+
+				for _, header := range tt.headers {
+					if response.Header.Get(header) != "" {
+						t.Errorf("resp.Headers(%v) got %v wanted no header", i, header)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
The headers output by this middleware "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset", "Retry-After" should be output depending on a configuration for it.