### PR TITLE
add RealIP methods

### DIFF
--- a/httprate.go
+++ b/httprate.go
@@ -22,7 +22,19 @@ func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Hand
 	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByIP))
 }
 
+func LimitByRealIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
+	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByRealIP))
+}
+
 func KeyByIP(r *http.Request) (string, error) {
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		ip = r.RemoteAddr
+	}
+	return canonicalizeIP(ip), nil
+}
+
+func KeyByRealIP(r *http.Request) (string, error) {
 	var ip string
 
 	if tcip := r.Header.Get("True-Client-IP"); tcip != "" {


### PR DESCRIPTION
note: slightly breaking change

This PR changes the behaviour of `KeyByIP` and `LimitByIP` to use the ip address from the http connection (request.RemoteAddr), as opposed to parsing it from the headers.

The PR also introduces `KeyByRealIP` and `LimitByRealIP` which will use headers like True-Client-IP, etc. to detect the IP address. You can use this if you trust the upstream load balancer to be serving you the correct True-Client-IP address (ie. like with Cloudflare which works well).
