### PR TITLE
pass request limit through context

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,7 +2,12 @@ package httprate
 
 import "context"
 
-var incrementKey = &struct{}{}
+type ctxKey int
+
+const (
+	incrementKey ctxKey = iota
+	requestLimitKey
+)
 
 func WithIncrement(ctx context.Context, value int) context.Context {
 	return context.WithValue(ctx, incrementKey, value)
@@ -13,4 +18,15 @@ func getIncrement(ctx context.Context) int {
 		return value
 	}
 	return 1
+}
+
+func WithRequestLimit(ctx context.Context, value int) context.Context {
+	return context.WithValue(ctx, requestLimitKey, value)
+}
+
+func getRequestLimit(ctx context.Context) int {
+	if value, ok := ctx.Value(requestLimitKey).(int); ok {
+		return value
+	}
+	return 0
 }


### PR DESCRIPTION
- Override default rate limit config value through context
- Useful when you want to have a specific rate limits for specific routes