### PR TITLE
Allow omitting or customizing response headers

### DIFF
--- a/httprate.go
+++ b/httprate.go
@@ -14,6 +14,15 @@ func Limit(requestLimit int, windowLength time.Duration, options ...Option) func
 type KeyFunc func(r *http.Request) (string, error)
 type Option func(rl *rateLimiter)
 
+// Set custom response headers. If empty, the header is omitted.
+type ResponseHeaders struct {
+	Limit      string // Default: X-RateLimit-Limit
+	Remaining  string // Default: X-RateLimit-Remaining
+	Increment  string // Default: X-RateLimit-Increment
+	Reset      string // Default: X-RateLimit-Reset
+	RetryAfter string // Default: Retry-After
+}
+
 func LimitAll(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
 	return Limit(requestLimit, windowLength)
 }
@@ -87,6 +96,12 @@ func WithLimitHandler(h http.HandlerFunc) Option {
 func WithLimitCounter(c LimitCounter) Option {
 	return func(rl *rateLimiter) {
 		rl.limitCounter = c
+	}
+}
+
+func WithResponseHeaders(headers ResponseHeaders) Option {
+	return func(rl *rateLimiter) {
+		rl.headers = headers
 	}
 }
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -238,36 +238,32 @@ func TestCustomResponseHeaders(t *testing.T) {
 
 			headers := recorder.Result().Header
 
-			if len(headers.Values("X-RateLimit-Limit")) != 0 {
-				t.Errorf("X-RateLimit-Limit header not expected")
-			}
-			if len(headers.Values("X-RateLimit-Remaining")) != 0 {
-				t.Errorf("X-RateLimit-Remaining header not expected")
-			}
-			if len(headers.Values("X-RateLimit-Reset")) != 0 {
-				t.Errorf("X-RateLimit-Reset header not expected")
-			}
-			if len(headers.Values("Retry-After")) != 0 {
-				t.Errorf("Retry-After header not expected")
-			}
-			if len(headers.Values("")) != 0 {
-				t.Errorf("'' header not expected")
+			for _, header := range []string{
+				"X-RateLimit-Limit",
+				"X-RateLimit-Remaining",
+				"X-RateLimit-Increment",
+				"X-RateLimit-Reset",
+				"Retry-After",
+				"", // ensure we don't set header with an empty key
+			} {
+				if len(headers.Values(header)) != 0 {
+					t.Errorf("%q header not expected", header)
+				}
 			}
 
-			if h := headers.Get(tt.headers.Limit); tt.headers.Limit != "" && h == "" {
-				t.Errorf("%s header expected", tt.headers.Limit)
-			}
-			if h := headers.Get(tt.headers.Remaining); tt.headers.Remaining != "" && h == "" {
-				t.Errorf("%s header expected", tt.headers.Remaining)
-			}
-			if h := headers.Get(tt.headers.Increment); tt.headers.Increment != "" && h == "" {
-				t.Errorf("%s header expected", tt.headers.Increment)
-			}
-			if h := headers.Get(tt.headers.Reset); tt.headers.Reset != "" && h == "" {
-				t.Errorf("%s header expected", tt.headers.Reset)
-			}
-			if h := headers.Get(tt.headers.RetryAfter); tt.headers.RetryAfter != "" && h == "" {
-				t.Errorf("%s header expected", tt.headers.RetryAfter)
+			for _, header := range []string{
+				tt.headers.Limit,
+				tt.headers.Remaining,
+				tt.headers.Increment,
+				tt.headers.Reset,
+				tt.headers.RetryAfter,
+			} {
+				if header == "" {
+					continue
+				}
+				if h := headers.Get(header); h == "" {
+					t.Errorf("%q header expected", header)
+				}
 			}
 		})
 	}

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -256,8 +256,6 @@ func TestCustomResponseHeaders(t *testing.T) {
 
 			if h := headers.Get(tt.headers.Limit); tt.headers.Limit != "" && h == "" {
 				t.Errorf("%s header expected", tt.headers.Limit)
-			} else {
-				t.Errorf("headers.Get(%v): %v", tt.headers.Limit, h)
 			}
 			if h := headers.Get(tt.headers.Remaining); tt.headers.Remaining != "" && h == "" {
 				t.Errorf("%s header expected", tt.headers.Remaining)

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -250,20 +250,25 @@ func TestCustomResponseHeaders(t *testing.T) {
 			if len(headers.Values("Retry-After")) != 0 {
 				t.Errorf("Retry-After header not expected")
 			}
-
-			if h := headers.Get(tt.headers.Limit); h == "" {
-				t.Errorf("%s header expected", tt.headers.Limit)
+			if len(headers.Values("")) != 0 {
+				t.Errorf("'' header not expected")
 			}
-			if h := headers.Get(tt.headers.Remaining); h == "" {
+
+			if h := headers.Get(tt.headers.Limit); tt.headers.Limit != "" && h == "" {
+				t.Errorf("%s header expected", tt.headers.Limit)
+			} else {
+				t.Errorf("headers.Get(%v): %v", tt.headers.Limit, h)
+			}
+			if h := headers.Get(tt.headers.Remaining); tt.headers.Remaining != "" && h == "" {
 				t.Errorf("%s header expected", tt.headers.Remaining)
 			}
-			if h := headers.Get(tt.headers.Increment); h == "" {
+			if h := headers.Get(tt.headers.Increment); tt.headers.Increment != "" && h == "" {
 				t.Errorf("%s header expected", tt.headers.Increment)
 			}
-			if h := headers.Get(tt.headers.Reset); h == "" {
+			if h := headers.Get(tt.headers.Reset); tt.headers.Reset != "" && h == "" {
 				t.Errorf("%s header expected", tt.headers.Reset)
 			}
-			if h := headers.Get(tt.headers.RetryAfter); h == "" {
+			if h := headers.Get(tt.headers.RetryAfter); tt.headers.RetryAfter != "" && h == "" {
 				t.Errorf("%s header expected", tt.headers.RetryAfter)
 			}
 		})


### PR DESCRIPTION
```go
httprate.Limit(
	1000,
	time.Minute,
	httprate.WithResponseHeaders(httprate.ResponseHeaders{
		Limit:      "X-RateLimit-Limit",
		Remaining:  "X-RateLimit-Remaining",
		Reset:      "X-RateLimit-Reset",
		RetryAfter: "Retry-After",
		Increment:  "", // omit
	}),
)
```