### PR TITLE
Export in-memory counter for external use

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -16,10 +16,6 @@ type LimitCounter interface {
 }
 
 func NewRateLimiter(requestLimit int, windowLength time.Duration, options ...Option) *rateLimiter {
-	return newRateLimiter(requestLimit, windowLength, options...)
-}
-
-func newRateLimiter(requestLimit int, windowLength time.Duration, options ...Option) *rateLimiter {
 	rl := &rateLimiter{
 		requestLimit: requestLimit,
 		windowLength: windowLength,
@@ -43,14 +39,10 @@ func newRateLimiter(requestLimit int, windowLength time.Duration, options ...Opt
 	}
 
 	if rl.limitCounter == nil {
-		rl.limitCounter = &localCounter{
-			latestWindow:     time.Now().UTC().Truncate(windowLength),
-			latestCounters:   make(map[uint64]int),
-			previousCounters: make(map[uint64]int),
-			windowLength:     windowLength,
-		}
+		rl.limitCounter = NewLocalLimitCounter(windowLength)
+	} else {
+		rl.limitCounter.Config(requestLimit, windowLength)
 	}
-	rl.limitCounter.Config(requestLimit, windowLength)
 
 	if rl.onRequestLimit == nil {
 		rl.onRequestLimit = func(w http.ResponseWriter, r *http.Request) {

--- a/local_counter_test.go
+++ b/local_counter_test.go
@@ -1,4 +1,4 @@
-package httprate
+package httprate_test
 
 import (
 	"fmt"
@@ -7,18 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/httprate"
 	"golang.org/x/sync/errgroup"
 )
 
 func TestLocalCounter(t *testing.T) {
-	limitCounter := &localCounter{
-		latestWindow:     time.Now().UTC().Truncate(time.Minute),
-		latestCounters:   make(map[uint64]int),
-		previousCounters: make(map[uint64]int),
-		windowLength:     time.Minute,
-	}
-
-	limitCounter.Config(1000, time.Minute)
+	limitCounter := httprate.NewLocalLimitCounter(time.Minute)
 
 	currentWindow := time.Now().UTC().Truncate(time.Minute)
 	previousWindow := currentWindow.Add(-time.Minute)
@@ -146,12 +140,7 @@ func TestLocalCounter(t *testing.T) {
 }
 
 func BenchmarkLocalCounter(b *testing.B) {
-	limitCounter := &localCounter{
-		latestWindow:     time.Now().UTC().Truncate(time.Minute),
-		latestCounters:   make(map[uint64]int),
-		previousCounters: make(map[uint64]int),
-		windowLength:     time.Minute,
-	}
+	limitCounter := httprate.NewLocalLimitCounter(time.Minute)
 
 	currentWindow := time.Now().UTC().Truncate(time.Minute)
 	previousWindow := currentWindow.Add(-time.Minute)


### PR DESCRIPTION
`httprate.NewLocalLimitCounter(windowLength)`

The idea is that other backends (e.g. https://github.com/go-chi/httprate-redis) could fall-back to the in-memory counter.