### PR TITLE
Local counter: Don't re-allocate maps in Go 1.21+

### DIFF
--- a/local_counter.go
+++ b/local_counter.go
@@ -68,23 +68,6 @@ func (c *localCounter) Increment(key string, currentWindow time.Time) error {
 	return c.IncrementBy(key, currentWindow, 1)
 }
 
-func (c *localCounter) evict(currentWindow time.Time) {
-	if c.latestWindow == currentWindow {
-		return
-	}
-
-	previousWindow := currentWindow.Add(-c.windowLength)
-	if c.latestWindow == previousWindow {
-		c.latestWindow = currentWindow
-		c.latestCounters, c.previousCounters = make(map[uint64]int), c.latestCounters
-		return
-	}
-
-	c.latestWindow = currentWindow
-	// NOTE: Don't use clear() to be compatible with older version of Go.
-	c.previousCounters, c.latestCounters = make(map[uint64]int), make(map[uint64]int)
-}
-
 func limitCounterKey(key string) uint64 {
 	h := xxhash.New()
 	h.WriteString(key)

--- a/local_counter_go1.20.go
+++ b/local_counter_go1.20.go
@@ -1,0 +1,21 @@
+//go:build !go1.21
+
+package httprate
+
+import "time"
+
+func (c *localCounter) evict(currentWindow time.Time) {
+	if c.latestWindow == currentWindow {
+		return
+	}
+
+	previousWindow := currentWindow.Add(-c.windowLength)
+	if c.latestWindow == previousWindow {
+		c.latestWindow = currentWindow
+		c.latestCounters, c.previousCounters = make(map[uint64]int), c.latestCounters
+		return
+	}
+
+	c.latestWindow = currentWindow
+	c.previousCounters, c.latestCounters = make(map[uint64]int), make(map[uint64]int)
+}

--- a/local_counter_go1.21.go
+++ b/local_counter_go1.21.go
@@ -1,0 +1,25 @@
+//go:build go1.21
+
+package httprate
+
+import "time"
+
+func (c *localCounter) evict(currentWindow time.Time) {
+	if c.latestWindow == currentWindow {
+		return
+	}
+
+	previousWindow := currentWindow.Add(-c.windowLength)
+	if c.latestWindow == previousWindow {
+		c.latestWindow = currentWindow
+		// Shift the windows without map re-allocation.
+		clear(c.previousCounters)
+		c.latestCounters, c.previousCounters = c.previousCounters, c.latestCounters
+		return
+	}
+
+	c.latestWindow = currentWindow
+
+	clear(c.previousCounters)
+	clear(c.latestCounters)
+}


### PR DESCRIPTION
Yet another performance improvement for Go 1.21+. Reuse maps backing the sliding windows to avoid map re-allocation, resizing and garbage collection when shifting the windows every second (or minute).

Speeds up throughput by 2.67x and reduces memory allocations by 2x on Go 1.21+ 🚀 

```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/go-chi/httprate
               │   old.txt   │               new.txt               │
               │   sec/op    │   sec/op     vs base                │
LocalCounter-8   34.65m ± 3%   12.99m ± 2%  -62.52% (p=0.000 n=10)

               │   old.txt    │               new.txt                │
               │     B/op     │     B/op      vs base                │
LocalCounter-8   4.384Mi ± 0%   2.846Mi ± 0%  -35.07% (p=0.000 n=10)

               │   old.txt   │               new.txt               │
               │  allocs/op  │  allocs/op   vs base                │
LocalCounter-8   253.9k ± 0%   121.6k ± 0%  -52.12% (p=0.000 n=10)
```

(The CI runs Go 1.17, so we won't see any difference there.)