### PR TITLE
Introduce RespondOnLimit() vs. OnLimit() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ r.Post("/login", func(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Rate-limit login at 5 req/min.
-	if loginRateLimiter.OnLimit(w, r, payload.Username) {
+	if loginRateLimiter.RespondOnLimit(w, r, payload.Username) {
 		return
 	}
 

--- a/_example/main.go
+++ b/_example/main.go
@@ -56,7 +56,7 @@ func main() {
 		}
 
 		// Rate-limit login at 5 req/min.
-		if loginRateLimiter.OnLimit(w, r, payload.Username) {
+		if loginRateLimiter.RespondOnLimit(w, r, payload.Username) {
 			return
 		}
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -454,7 +454,7 @@ func TestRateLimitPayload(t *testing.T) {
 		}
 
 		// Rate-limit login at 5 req/min.
-		if loginRateLimiter.OnLimit(w, r, payload.Username) {
+		if loginRateLimiter.RespondOnLimit(w, r, payload.Username) {
 			return
 		}
 


### PR DESCRIPTION
Split the new `.OnLimit()` method into two explicit methods.

1. `RespondOnLimit()` sends HTTP response
2. `OnLimit()` doesn't

The `OnLimit()` method will be useful to use with tools like https://github.com/webrpc/webrpc, which always return some JSON payload and can't halt further request execution like regular HTTP handlers.