### PR TITLE
Add httpate.Key(string) helper for static keys

### DIFF
--- a/httprate.go
+++ b/httprate.go
@@ -35,6 +35,12 @@ func LimitByRealIP(requestLimit int, windowLength time.Duration) func(next http.
 	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByRealIP))
 }
 
+func Key(key string) func(r *http.Request) (string, error) {
+	return func(r *http.Request) (string, error) {
+		return key, nil
+	}
+}
+
 func KeyByIP(r *http.Request) (string, error) {
 	ip, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/limiter.go
+++ b/limiter.go
@@ -33,9 +33,7 @@ func NewRateLimiter(requestLimit int, windowLength time.Duration, options ...Opt
 	}
 
 	if rl.keyFn == nil {
-		rl.keyFn = func(r *http.Request) (string, error) {
-			return "*", nil
-		}
+		rl.keyFn = Key("*")
 	}
 
 	if rl.limitCounter == nil {


### PR DESCRIPTION
Useful to create compounds with a custom prefix