### PR TITLE
Use `WithRequestLimit` with `0` to skip rate limit

### DIFF
--- a/context.go
+++ b/context.go
@@ -13,20 +13,16 @@ func WithIncrement(ctx context.Context, value int) context.Context {
 	return context.WithValue(ctx, incrementKey, value)
 }
 
-func getIncrement(ctx context.Context) int {
-	if value, ok := ctx.Value(incrementKey).(int); ok {
-		return value
-	}
-	return 1
+func getIncrement(ctx context.Context) (int, bool) {
+	value, ok := ctx.Value(incrementKey).(int)
+	return value, ok
 }
 
 func WithRequestLimit(ctx context.Context, value int) context.Context {
 	return context.WithValue(ctx, requestLimitKey, value)
 }
 
-func getRequestLimit(ctx context.Context) int {
-	if value, ok := ctx.Value(requestLimitKey).(int); ok {
-		return value
-	}
-	return 0
+func getRequestLimit(ctx context.Context) (int, bool) {
+	value, ok := ctx.Value(requestLimitKey).(int)
+	return value, ok
 }

--- a/context.go
+++ b/context.go
@@ -9,8 +9,6 @@ const (
 	requestLimitKey
 )
 
-const _NoLimit = -1
-
 func WithIncrement(ctx context.Context, value int) context.Context {
 	return context.WithValue(ctx, incrementKey, value)
 }
@@ -21,7 +19,7 @@ func getIncrement(ctx context.Context) (int, bool) {
 }
 
 func WithNoLimit(ctx context.Context) context.Context {
-	return context.WithValue(ctx, requestLimitKey, _NoLimit)
+	return context.WithValue(ctx, requestLimitKey, -1)
 }
 
 func WithRequestLimit(ctx context.Context, value int) context.Context {

--- a/context.go
+++ b/context.go
@@ -9,6 +9,8 @@ const (
 	requestLimitKey
 )
 
+const _NoLimit = -1
+
 func WithIncrement(ctx context.Context, value int) context.Context {
 	return context.WithValue(ctx, incrementKey, value)
 }
@@ -16,6 +18,10 @@ func WithIncrement(ctx context.Context, value int) context.Context {
 func getIncrement(ctx context.Context) (int, bool) {
 	value, ok := ctx.Value(incrementKey).(int)
 	return value, ok
+}
+
+func WithNoLimit(ctx context.Context) context.Context {
+	return context.WithValue(ctx, requestLimitKey, _NoLimit)
 }
 
 func WithRequestLimit(ctx context.Context, value int) context.Context {

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.17
 
 require github.com/cespare/xxhash/v2 v2.3.0
 
-require golang.org/x/sync v0.7.0 // indirect
+require golang.org/x/sync v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
-github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/limiter.go
+++ b/limiter.go
@@ -72,8 +72,6 @@ func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string
 	currentWindow := time.Now().UTC().Truncate(l.windowLength)
 	ctx := r.Context()
 
-	setHeader(w, l.headers.Reset, fmt.Sprintf("%d", currentWindow.Add(l.windowLength).Unix()))
-
 	limit, ok := getRequestLimit(ctx)
 	if !ok {
 		limit = l.requestLimit
@@ -86,6 +84,8 @@ func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string
 	if limit == -1 {
 		return false
 	}
+
+	setHeader(w, l.headers.Reset, fmt.Sprintf("%d", currentWindow.Add(l.windowLength).Unix()))
 	setHeader(w, l.headers.Limit, fmt.Sprintf("%d", limit))
 
 	increment, ok := getIncrement(r.Context())

--- a/limiter.go
+++ b/limiter.go
@@ -76,8 +76,8 @@ func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string
 	if !ok {
 		limit = l.requestLimit
 	}
-	setHeader(w, l.headers.Reset, fmt.Sprintf("%d", currentWindow.Add(l.windowLength).Unix()))
 	setHeader(w, l.headers.Limit, fmt.Sprintf("%d", limit))
+	setHeader(w, l.headers.Reset, fmt.Sprintf("%d", currentWindow.Add(l.windowLength).Unix()))
 
 	// If the limit is set to 0, we always limit
 	if limit == 0 {

--- a/limiter.go
+++ b/limiter.go
@@ -78,12 +78,12 @@ func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string
 	if !ok {
 		limit = l.requestLimit
 	}
-	// If the limit is set to 0, we are always over limit
+	// If the limit is set to 0, we always limit
 	if limit == 0 {
 		return true
 	}
-	// If the limit is set to -1, we are never over limit
-	if limit == _NoLimit {
+	// If the limit is set to -1, there is no limit
+	if limit == -1 {
 		return false
 	}
 
@@ -91,7 +91,7 @@ func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string
 	if !ok {
 		increment = 1
 	}
-	// If the increment is 0, we are always on limit
+	// If the increment is 0, we do not limit
 	if increment == 0 {
 		return false
 	}

--- a/limiter.go
+++ b/limiter.go
@@ -86,20 +86,18 @@ func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string
 	if limit == -1 {
 		return false
 	}
+	setHeader(w, l.headers.Limit, fmt.Sprintf("%d", limit))
 
 	increment, ok := getIncrement(r.Context())
 	if !ok {
 		increment = 1
 	}
+	if increment != 1 {
+		setHeader(w, l.headers.Increment, fmt.Sprintf("%d", increment))
+	}
 	// If the increment is 0, we do not limit
 	if increment == 0 {
 		return false
-	}
-
-	setHeader(w, l.headers.Limit, fmt.Sprintf("%d", limit))
-
-	if increment > 1 {
-		setHeader(w, l.headers.Increment, fmt.Sprintf("%d", increment))
 	}
 
 	l.mu.Lock()

--- a/limiter.go
+++ b/limiter.go
@@ -76,17 +76,18 @@ func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string
 	if !ok {
 		limit = l.requestLimit
 	}
+	setHeader(w, l.headers.Reset, fmt.Sprintf("%d", currentWindow.Add(l.windowLength).Unix()))
+	setHeader(w, l.headers.Limit, fmt.Sprintf("%d", limit))
+
 	// If the limit is set to 0, we always limit
 	if limit == 0 {
+		setHeader(w, l.headers.Remaining, "0")
 		return true
 	}
 	// If the limit is set to -1, there is no limit
 	if limit == -1 {
 		return false
 	}
-
-	setHeader(w, l.headers.Reset, fmt.Sprintf("%d", currentWindow.Add(l.windowLength).Unix()))
-	setHeader(w, l.headers.Limit, fmt.Sprintf("%d", limit))
 
 	increment, ok := getIncrement(r.Context())
 	if !ok {

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -141,8 +141,8 @@ func TestResponseHeaders(t *testing.T) {
 			requestsLimit:       5,
 			increments:          []int{0, 0, 0, 0, 0, 0},
 			respCodes:           []int{200, 200, 200, 200, 200, 200},
-			respLimitHeader:     []string{"5", "5", "5", "5", "5", "5"},
-			respRemainingHeader: []string{"5", "5", "5", "5", "5", "5"},
+			respLimitHeader:     []string{"", "", "", "", "", ""},
+			respRemainingHeader: []string{"", "", "", "", "", ""},
 		},
 		{
 			name:                "always block",

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -141,7 +141,7 @@ func TestResponseHeaders(t *testing.T) {
 			requestsLimit:       5,
 			increments:          []int{0, 0, 0, 0, 0, 0},
 			respCodes:           []int{200, 200, 200, 200, 200, 200},
-			respLimitHeader:     []string{"", "", "", "", "", ""},
+			respLimitHeader:     []string{"5", "5", "5", "5", "5", "5"},
 			respRemainingHeader: []string{"", "", "", "", "", ""},
 		},
 		{


### PR DESCRIPTION
This PR adds the capability of skipping rate limit by specifying 0