### PR TITLE
Update README.md: add missing 'time' import in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ package main
 
 import (
 	"net/http"
+    "time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ package main
 
 import (
 	"net/http"
-    "time"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"


### PR DESCRIPTION
### Description
This PR fixes an issue in the `README.md` code example where the `time` package is not imported. Without this import, users attempting to run the example code receive the following error:
```
./main.go:23:32: undefined: time
```

### Changes
- Added the missing `time` import in the `README.md` example code.

### Motivation
Adding the `time` import improves the accuracy of the README example, allowing users to copy and run the example without encountering errors.
