### PR TITLE
local counter: align windows to reset at sub-millisecond counter start

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -37,6 +37,11 @@ func NewRateLimiter(requestLimit int, windowLength time.Duration, options ...Opt
 	}
 
 	if rl.limitCounter == nil {
+		// Align windows to this limiter's start instant, not the wall clock, so resets
+		// spread out instead of all snapping to the same instant (e.g. the exact second).
+		// Safe only in-process; custom counters (e.g. Redis) stay wall-clock-aligned.
+		start := time.Now().UTC()
+		rl.windowOffset = start.Sub(start.Truncate(windowLength))
 		rl.limitCounter = NewLocalLimitCounter(windowLength)
 	} else {
 		rl.limitCounter.Config(requestLimit, windowLength)
@@ -56,6 +61,7 @@ func NewRateLimiter(requestLimit int, windowLength time.Duration, options ...Opt
 type RateLimiter struct {
 	requestLimit  int
 	windowLength  time.Duration
+	windowOffset  time.Duration
 	keyFn         KeyFunc
 	limitCounter  LimitCounter
 	onRateLimited http.HandlerFunc
@@ -69,7 +75,7 @@ type RateLimiter struct {
 // it increments the request count and returns false. This method does not send an HTTP response,
 // so the caller must handle the response themselves or use the RespondOnLimit() method instead.
 func (l *RateLimiter) OnLimit(w http.ResponseWriter, r *http.Request, key string) bool {
-	currentWindow := time.Now().UTC().Truncate(l.windowLength)
+	currentWindow := l.currentWindow(time.Now().UTC())
 	ctx := r.Context()
 
 	limit := l.requestLimit
@@ -149,9 +155,16 @@ func (l *RateLimiter) Handler(next http.Handler) http.Handler {
 	})
 }
 
+// currentWindow returns the start of the rate-limit window containing t, aligned
+// to windowOffset rather than the wall clock. When windowOffset is zero this is a
+// plain truncation. The result is always in (t-windowLength, t].
+func (l *RateLimiter) currentWindow(t time.Time) time.Time {
+	return t.Add(-l.windowOffset).Truncate(l.windowLength).Add(l.windowOffset)
+}
+
 func (l *RateLimiter) calculateRate(key string, requestLimit int) (bool, float64, error) {
 	now := time.Now().UTC()
-	currentWindow := now.Truncate(l.windowLength)
+	currentWindow := l.currentWindow(now)
 	previousWindow := currentWindow.Add(-l.windowLength)
 
 	currCount, prevCount, err := l.limitCounter.Get(key, currentWindow, previousWindow)

--- a/limiter_internal_test.go
+++ b/limiter_internal_test.go
@@ -1,0 +1,83 @@
+package httprate
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCurrentWindowOffset verifies that rate-limit windows are aligned to the
+// limiter's sub-window offset rather than to the wall clock, so that resets are
+// spread out instead of all snapping to the same instant (e.g. the exact second).
+func TestCurrentWindowOffset(t *testing.T) {
+	const windowLength = time.Second
+
+	for _, offset := range []time.Duration{
+		0,
+		347 * time.Millisecond,
+		windowLength - time.Nanosecond,
+	} {
+		l := &RateLimiter{windowLength: windowLength, windowOffset: offset}
+
+		// A time sitting exactly on an offset boundary maps to itself.
+		base := time.Unix(1000, 0).UTC().Add(offset)
+		if got := l.currentWindow(base); !got.Equal(base) {
+			t.Fatalf("offset=%v: currentWindow(boundary) = %v, want %v", offset, got, base)
+		}
+
+		// Windows are windowLength apart and aligned to the offset: every window
+		// start minus the offset lands exactly on a wall-clock multiple.
+		for _, d := range []time.Duration{0, time.Nanosecond, 250 * time.Millisecond, windowLength - time.Nanosecond} {
+			now := base.Add(d)
+			w := l.currentWindow(now)
+
+			// Result is in (now-windowLength, now].
+			if w.After(now) || !w.After(now.Add(-windowLength)) {
+				t.Errorf("offset=%v d=%v: currentWindow(%v) = %v out of (now-window, now]", offset, d, now, w)
+			}
+			// Aligned to the offset, not the wall clock.
+			if rem := w.Add(-offset).UnixNano() % int64(windowLength); rem != 0 {
+				t.Errorf("offset=%v d=%v: window %v not aligned to offset (rem=%v)", offset, d, w, rem)
+			}
+			// Same offset-window for any moment inside it.
+			if !w.Equal(base) {
+				t.Errorf("offset=%v d=%v: currentWindow(%v) = %v, want %v", offset, d, now, w, base)
+			}
+		}
+
+		// The next window is exactly windowLength later.
+		next := l.currentWindow(base.Add(windowLength))
+		if want := base.Add(windowLength); !next.Equal(want) {
+			t.Errorf("offset=%v: next window = %v, want %v", offset, next, want)
+		}
+	}
+}
+
+// TestLocalCounterWindowOffset verifies the default in-process backend makes the
+// limiter derive a sub-window offset, while a custom counter keeps wall-clock-
+// aligned windows.
+func TestLocalCounterWindowOffset(t *testing.T) {
+	const windowLength = time.Second
+
+	// Default limiter uses the local counter and derives a sub-window offset.
+	rl := NewRateLimiter(10, windowLength)
+	if off := rl.windowOffset; off < 0 || off >= windowLength {
+		t.Errorf("limiter windowOffset = %v, want [0, %v)", off, windowLength)
+	}
+
+	// A custom counter keeps wall-clock alignment (offset stays zero).
+	rl2 := NewRateLimiter(10, windowLength, WithLimitCounter(noOffsetCounter{}))
+	if rl2.windowOffset != 0 {
+		t.Errorf("limiter windowOffset with custom counter = %v, want 0", rl2.windowOffset)
+	}
+}
+
+// noOffsetCounter is a minimal custom LimitCounter, standing in for a distributed
+// backend (e.g. Redis), to confirm the offset applies only to the local counter.
+type noOffsetCounter struct{}
+
+func (noOffsetCounter) Config(int, time.Duration)                {}
+func (noOffsetCounter) Increment(string, time.Time) error        { return nil }
+func (noOffsetCounter) IncrementBy(string, time.Time, int) error { return nil }
+func (noOffsetCounter) Get(string, time.Time, time.Time) (int, int, error) {
+	return 0, 0, nil
+}

--- a/local_counter.go
+++ b/local_counter.go
@@ -14,7 +14,7 @@ import (
 func NewLocalLimitCounter(windowLength time.Duration) *localCounter {
 	return &localCounter{
 		windowLength:     windowLength,
-		latestWindow:     time.Now().UTC().Truncate(windowLength),
+		latestWindow:     time.Now().UTC(),
 		latestCounters:   make(map[uint64]int),
 		previousCounters: make(map[uint64]int),
 	}


### PR DESCRIPTION
Windows now align to the limiter's start instant rather than the wall clock, so
resets spread out instead of all snapping to the same moment (e.g. the exact
second). The offset lives only on the RateLimiter (its sole consumer); the local
counter carries no redundant copy. Distributed counters (e.g. Redis) keep
wall-clock alignment.