### PR TITLE
test: drop golang.org/x/sync dependency (errgroup → sync.WaitGroup)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,4 @@ require github.com/zeebo/xxh3 v1.0.2
 
 require golang.org/x/sys v0.30.0 // indirect
 
-require (
-	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
-	golang.org/x/sync v0.12.0
-)
+require github.com/klauspost/cpuid/v2 v2.2.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,5 @@ github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/local_counter_test.go
+++ b/local_counter_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-chi/httprate"
-	"golang.org/x/sync/errgroup"
 )
 
 func TestLocalCounter(t *testing.T) {
@@ -102,40 +101,42 @@ func TestLocalCounter(t *testing.T) {
 		}
 
 		if tt.incrBy > 0 {
-			var g errgroup.Group
+			var wg sync.WaitGroup
 			for i := 0; i < concurrentRequests; i++ {
 				i := i
-				g.Go(func() error {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
 					key := fmt.Sprintf("key:%v", i)
-					return limitCounter.IncrementBy(key, currentWindow, tt.incrBy)
-				})
+					if err := limitCounter.IncrementBy(key, currentWindow, tt.incrBy); err != nil {
+						t.Errorf("%s: %v", tt.name, err)
+					}
+				}()
 			}
-			if err := g.Wait(); err != nil {
-				t.Errorf("%s: %v", tt.name, err)
-			}
+			wg.Wait()
 		}
 
-		var g errgroup.Group
+		var wg sync.WaitGroup
 		for i := 0; i < concurrentRequests; i++ {
 			i := i
-			g.Go(func() error {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
 				key := fmt.Sprintf("key:%v", i)
 				curr, prev, err := limitCounter.Get(key, currentWindow, previousWindow)
 				if err != nil {
-					return fmt.Errorf("%q: %w", key, err)
+					t.Errorf("%s: %q: %v", tt.name, key, err)
+					return
 				}
 				if curr != tt.curr {
-					return fmt.Errorf("%q: unexpected curr = %v, expected %v", key, curr, tt.curr)
+					t.Errorf("%s: %q: unexpected curr = %v, expected %v", tt.name, key, curr, tt.curr)
 				}
 				if prev != tt.prev {
-					return fmt.Errorf("%q: unexpected prev = %v, expected %v", key, prev, tt.prev)
+					t.Errorf("%s: %q: unexpected prev = %v, expected %v", tt.name, key, prev, tt.prev)
 				}
-				return nil
-			})
+			}()
 		}
-		if err := g.Wait(); err != nil {
-			t.Errorf("%s: %v", tt.name, err)
-		}
+		wg.Wait()
 	}
 }
 


### PR DESCRIPTION
Removes the `golang.org/x/sync` dependency, which was only used by the test suite (`errgroup` in `local_counter_test.go`). The concurrent test goroutines now report failures directly via `t.Errorf` (safe for concurrent use), so `errgroup`'s error aggregation isn't needed.

This is one part of reducing the module's dependency footprint as **suggested by @lrstanley in #57**. Credit for the idea goes to them.

Note: `x/sync` is a *test-only* dependency, so it doesn't propagate to consumers' builds — the benefit here is a tidier `go.mod` rather than a change to the dependency graph downstream users see. The `zeebo/xxh3` part of #57 is handled/discussed separately.

- `go test ./...` passes
- `go mod tidy` drops `golang.org/x/sync` from `go.mod`/`go.sum`

🤖 Prepared with the help of Claude (AI), reviewed before opening.