### PR TITLE
Deprecate spoofable RealIP rate-limiting; add LimitBy + KeyFromContext and modernize the key API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+
+      - name: Test example (chi integration)
+        run: cd ./_example && go test -v ./...

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ func main() {
 	// not the client — rate-limit by a trusted client IP instead. See
 	// "Rate limit by client IP behind a proxy" below.
 	//
-	// To have a single rate-limiter for all requests, use httprate.LimitAll(..).
+	// To have a single rate-limiter for all requests, use a constant key:
+	// httprate.LimitBy(.., httprate.Key("*")).
 	//
 	// Please see _example/main.go for more, or read the library code.
 	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyByIP))
@@ -178,9 +179,10 @@ r.Post("/login", func(w http.ResponseWriter, r *http.Request) {
 The default response is `HTTP 429` with `Too Many Requests` body. You can override it with:
 
 ```go
-r.Use(httprate.Limit(
+r.Use(httprate.LimitBy(
 	10,
 	time.Minute,
+	httprate.KeyByIP,
 	httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error": "Rate-limited. Please, slow down."}`, http.StatusTooManyRequests)
 	}),
@@ -196,9 +198,10 @@ An error can be returned by:
     - Backends that fall-back to the local in-memory counter (e.g. [httprate-redis](https://github.com/go-chi/httprate-redis)) can choose not to return any errors either
 
 ```go
-r.Use(httprate.Limit(
+r.Use(httprate.LimitBy(
 	10,
 	time.Minute,
+	httprate.KeyByIP,
 	httprate.WithErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
 		http.Error(w, fmt.Sprintf(`{"error": %q}`, err), http.StatusPreconditionRequired)
 	}),
@@ -209,9 +212,10 @@ r.Use(httprate.Limit(
 ### Send custom response headers
 
 ```go
-r.Use(httprate.Limit(
+r.Use(httprate.LimitBy(
 	1000,
 	time.Minute,
+	httprate.KeyByIP,
 	httprate.WithResponseHeaders(httprate.ResponseHeaders{
 		Limit:      "X-RateLimit-Limit",
 		Remaining:  "X-RateLimit-Remaining",
@@ -225,9 +229,10 @@ r.Use(httprate.Limit(
 ### Omit response headers
 
 ```go
-r.Use(httprate.Limit(
+r.Use(httprate.LimitBy(
 	1000,
 	time.Minute,
+	httprate.KeyByIP,
 	httprate.WithResponseHeaders(httprate.ResponseHeaders{}),
 ))
 ```

--- a/README.md
+++ b/README.md
@@ -51,20 +51,25 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 
-	// Enable httprate request limiter of 100 requests per minute.
+	// Enable httprate request limiter of 100 requests per minute, keyed by the
+	// client IP.
 	//
-	// In the code example below, rate-limiting is bound to the request's
-	// RemoteAddr (the TCP peer) via the KeyByIP key function.
-	//
-	// If your app runs behind a reverse proxy or CDN, RemoteAddr is the proxy,
-	// not the client — rate-limit by a trusted client IP instead. See
-	// "Rate limit by client IP behind a proxy" below.
+	// There is no safe default IP source, so you state your trust model
+	// explicitly: one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+)
+	// resolves the client IP into the request context, and
+	// KeyFromContext(middleware.GetClientIP) reads it. Pick the chi
+	// ClientIPFrom* that matches your deployment — here we assume
+	// the server is directly exposed to clients (no proxy), so the client IP is
+	// the TCP peer (RemoteAddr). Behind a reverse proxy or CDN, use
+	// ClientIPFromXFF / ClientIPFromHeader instead; see "Rate limit by client IP
+	// behind a proxy" below.
 	//
 	// To have a single rate-limiter for all requests, use a constant key:
 	// httprate.LimitBy(.., httprate.Key("*")).
 	//
 	// Please see _example/main.go for more, or read the library code.
-	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyByIP))
+	r.Use(middleware.ClientIPFromRemoteAddr)
+	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("."))
@@ -133,7 +138,7 @@ context.
 r.Use(httprate.LimitBy(
 	10,             // requests
 	10*time.Second, // per duration
-	httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint),
+	httprate.JoinKeys(httprate.KeyFromContext(middleware.GetClientIP), httprate.KeyByEndpoint),
 ))
 ```
 
@@ -182,7 +187,7 @@ The default response is `HTTP 429` with `Too Many Requests` body. You can overri
 r.Use(httprate.LimitBy(
 	10,
 	time.Minute,
-	httprate.KeyByIP,
+	httprate.KeyFromContext(middleware.GetClientIP),
 	httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error": "Rate-limited. Please, slow down."}`, http.StatusTooManyRequests)
 	}),
@@ -201,7 +206,7 @@ An error can be returned by:
 r.Use(httprate.LimitBy(
 	10,
 	time.Minute,
-	httprate.KeyByIP,
+	httprate.KeyFromContext(middleware.GetClientIP),
 	httprate.WithErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
 		http.Error(w, fmt.Sprintf(`{"error": %q}`, err), http.StatusPreconditionRequired)
 	}),
@@ -215,7 +220,7 @@ r.Use(httprate.LimitBy(
 r.Use(httprate.LimitBy(
 	1000,
 	time.Minute,
-	httprate.KeyByIP,
+	httprate.KeyFromContext(middleware.GetClientIP),
 	httprate.WithResponseHeaders(httprate.ResponseHeaders{
 		Limit:      "X-RateLimit-Limit",
 		Remaining:  "X-RateLimit-Remaining",
@@ -232,7 +237,7 @@ r.Use(httprate.LimitBy(
 r.Use(httprate.LimitBy(
 	1000,
 	time.Minute,
-	httprate.KeyByIP,
+	httprate.KeyFromContext(middleware.GetClientIP),
 	httprate.WithResponseHeaders(httprate.ResponseHeaders{}),
 ))
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@
 `net/http` request rate limiter based on the Sliding Window Counter pattern inspired by
 CloudFlare https://blog.cloudflare.com/counting-things-a-lot-of-different-things.
 
+> [!WARNING]
+> **Security: `LimitByRealIP` / `KeyByRealIP` / `WithKeyByRealIP` are deprecated.**
+> They derive the rate-limit key from client-supplied headers (`True-Client-IP`,
+> `X-Real-IP`, `X-Forwarded-For`) with no proxy-trust check, so a remote
+> attacker can spoof the key — either rotating it to **evade** the limit or
+> pinning it to a victim's IP to **lock that victim out** (HTTP 429). This is the
+> same flaw fixed in chi's `middleware.RealIP` (see
+> [GHSA-9g5q-2w5x-hmxf](https://github.com/go-chi/chi/security/advisories/GHSA-9g5q-2w5x-hmxf),
+> [GHSA-rjr7-jggh-pgcp](https://github.com/go-chi/chi/security/advisories/GHSA-rjr7-jggh-pgcp),
+> [GHSA-3fxj-6jh8-hvhx](https://github.com/go-chi/chi/security/advisories/GHSA-3fxj-6jh8-hvhx)).
+> Rate-limit by a **trusted** client IP instead — see
+> [Rate limit by client IP behind a proxy](#rate-limit-by-client-ip-behind-a-proxy).
+
 The sliding window counter pattern is accurate, smooths traffic and offers a simple counter
 design to share a rate-limit among a cluster of servers. For example, if you'd like
 to use redis to coordinate a rate-limit across a group of microservices you just need
@@ -40,13 +53,17 @@ func main() {
 
 	// Enable httprate request limiter of 100 requests per minute.
 	//
-	// In the code example below, rate-limiting is bound to the request IP address
-	// via the LimitByIP middleware handler.
+	// In the code example below, rate-limiting is bound to the request's
+	// RemoteAddr (the TCP peer) via the KeyByIP key function.
+	//
+	// If your app runs behind a reverse proxy or CDN, RemoteAddr is the proxy,
+	// not the client — rate-limit by a trusted client IP instead. See
+	// "Rate limit by client IP behind a proxy" below.
 	//
 	// To have a single rate-limiter for all requests, use httprate.LimitAll(..).
 	//
-	// Please see _example/main.go for other more, or read the library code.
-	r.Use(httprate.LimitByIP(100, time.Minute))
+	// Please see _example/main.go for more, or read the library code.
+	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyByIP))
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("."))
@@ -58,24 +75,76 @@ func main() {
 
 ## Common use cases
 
+### Rate limit by client IP behind a proxy
+
+If your app runs behind a reverse proxy, load balancer, or CDN, the request's
+`RemoteAddr` is the proxy, not the client. Resolving the real client IP safely
+means deciding *which* hop to trust — there is no safe default, and trusting a
+client-supplied header blindly is exactly the spoofing bug behind the deprecated
+`LimitByRealIP`.
+
+Use chi's [`middleware.ClientIPFrom*`](https://pkg.go.dev/github.com/go-chi/chi/v5/middleware#ClientIPFromXFF)
+middlewares (chi `v5.3.0+`) to resolve a trusted client IP, then rate-limit by
+it with `LimitBy` + `KeyFromContext(middleware.GetClientIP)`:
+
+```go
+import (
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/httprate"
+)
+
+// 1. Resolve a trusted client IP. Pick exactly ONE that matches your
+//    deployment (see the table below):
+r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+
+// 2. Rate-limit by that trusted client IP.
+r.Use(httprate.LimitBy(100, time.Minute,
+	httprate.KeyFromContext(middleware.GetClientIP),
+))
+```
+
+Pick the one `ClientIPFrom*` middleware that matches how requests reach you:
+
+| Your setup | Use |
+| --- | --- |
+| Directly on the public internet, no proxy | `middleware.ClientIPFromRemoteAddr` |
+| Behind nginx (`X-Real-IP`), Cloudflare (`CF-Connecting-IP`), Apache (`X-Client-IP`) | `middleware.ClientIPFromHeader("X-Real-IP")` |
+| Behind one or more proxies whose IP ranges you can list | `middleware.ClientIPFromXFF("10.0.0.0/8", ...)` |
+| Behind a known, fixed number of proxies with dynamic IPs | `middleware.ClientIPFromXFFTrustedProxies(2)` |
+
+See chi's [Choosing a ClientIP middleware](https://pkg.go.dev/github.com/go-chi/chi/v5/middleware#hdr-Choosing_a_ClientIP_middleware)
+for the full picker.
+
+> [!IMPORTANT]
+> If no `ClientIPFrom*` middleware is installed upstream, `middleware.GetClientIP`
+> returns `""` and **every request shares a single global rate-limit bucket**.
+> That's strictly more restrictive (not a security hole), but it's a footgun —
+> you'll trip the limit after `requestLimit` total requests in dev. Make sure
+> exactly one `ClientIPFrom*` middleware runs before the limiter.
+
+`KeyFromContext` is generic over `func(context.Context) string`, so it isn't
+tied to chi — pass your own extractor for echo, fiber, gin, or custom
+middleware that stashes the client IP (or tenant/user ID) in the request
+context.
+
 ### Rate limit by IP and URL path (aka endpoint)
 ```go
-r.Use(httprate.Limit(
+r.Use(httprate.LimitBy(
 	10,             // requests
 	10*time.Second, // per duration
-	httprate.WithKeyFuncs(httprate.KeyByIP, httprate.KeyByEndpoint),
+	httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint),
 ))
 ```
 
 ### Rate limit by arbitrary keys
 ```go
-r.Use(httprate.Limit(
+r.Use(httprate.LimitBy(
 	100,
 	time.Minute,
 	// an oversimplified example of rate limiting by a custom header
-	httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
+	func(r *http.Request) (string, error) {
 		return r.Header.Get("X-Access-Token"), nil
-	}),
+	},
 ))
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ func main() {
 	// To have a single rate-limiter for all requests, use a constant key:
 	// httprate.LimitBy(.., httprate.Key("*")).
 	//
+	// NOTE: middleware.GetClientIP returns the full client IP. To stop IPv6
+	// clients from rotating within their /64 to win fresh buckets, canonicalize
+	// the IP to /64 — see "Rate limit by client IP behind a proxy" below and
+	// _example/main.go.
+	//
 	// Please see _example/main.go for more, or read the library code.
 	r.Use(middleware.ClientIPFromRemoteAddr)
 	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
@@ -91,10 +96,13 @@ client-supplied header blindly is exactly the spoofing bug behind the deprecated
 
 Use chi's [`middleware.ClientIPFrom*`](https://pkg.go.dev/github.com/go-chi/chi/v5/middleware#ClientIPFromXFF)
 middlewares (chi `v5.3.0+`) to resolve a trusted client IP, then rate-limit by
-it with `LimitBy` + `KeyFromContext(middleware.GetClientIP)`:
+it with `LimitBy` + `KeyFromContext`:
 
 ```go
 import (
+	"context"
+	"net/netip"
+
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/httprate"
 )
@@ -105,9 +113,34 @@ r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
 
 // 2. Rate-limit by that trusted client IP.
 r.Use(httprate.LimitBy(100, time.Minute,
-	httprate.KeyFromContext(middleware.GetClientIP),
+	httprate.KeyFromContext(clientIPKey),
 ))
+
+// clientIPKey reads the trusted client IP resolved in step 1 and canonicalizes
+// it for rate-limiting. chi's middleware.GetClientIPAddr returns the *full*
+// client IP as a net/netip.Addr; we bucket IPv6 clients by their /64 prefix so
+// a client can't rotate within its own /64 (2^64 addresses via SLAAC) to win a
+// fresh bucket on every request. IPv4 is used as-is.
+func clientIPKey(ctx context.Context) string {
+	ip := middleware.GetClientIPAddr(ctx)
+	if !ip.IsValid() {
+		return "" // no ClientIPFrom* upstream — see the note below
+	}
+	if ip.Is4() {
+		return ip.String()
+	}
+	return netip.PrefixFrom(ip, 64).Masked().Addr().String() // IPv6 → /64
+}
 ```
+
+> [!NOTE]
+> Rate-limiting by the full IPv6 address (`KeyFromContext(middleware.GetClientIP)`)
+> lets an IPv6 client rotate within its own `/64` to get a fresh bucket per
+> request and bypass the limit. The `clientIPKey` helper above buckets IPv6 by
+> `/64` — adjust the prefix (e.g. `/56`, `/48`) if your clients are delegated a
+> larger block. The deprecated `KeyByIP` / `KeyByRealIP` did this `/64`
+> canonicalization for you; the explicit helper keeps it while making the trust
+> model and prefix your choice.
 
 Pick the one `ClientIPFrom*` middleware that matches how requests reach you:
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ context.
 r.Use(httprate.LimitBy(
 	10,             // requests
 	10*time.Second, // per duration
-	httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint),
+	httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint),
 ))
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,25 +56,24 @@ func main() {
 	//
 	// There is no safe default IP source, so you state your trust model
 	// explicitly: one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+)
-	// resolves the client IP into the request context, and
-	// KeyFromContext(middleware.GetClientIP) reads it. Pick the chi
-	// ClientIPFrom* that matches your deployment — here we assume
-	// the server is directly exposed to clients (no proxy), so the client IP is
-	// the TCP peer (RemoteAddr). Behind a reverse proxy or CDN, use
-	// ClientIPFromXFF / ClientIPFromHeader instead; see "Rate limit by client IP
-	// behind a proxy" below.
+	// resolves the client IP, and the KeyFunc reads it back with
+	// middleware.GetClientIP. Pick the chi ClientIPFrom* that matches your
+	// deployment — here we assume the server is directly exposed to clients (no
+	// proxy), so the client IP is the TCP peer (RemoteAddr). Behind a reverse
+	// proxy or CDN, use ClientIPFromXFF / ClientIPFromHeader instead; see "Rate
+	// limit by client IP behind a proxy" below.
+	//
+	// httprate.CanonicalizeIP buckets IPv6 clients by their /64 so they can't
+	// rotate within it to win fresh buckets (see that section for why).
 	//
 	// To have a single rate-limiter for all requests, use a constant key:
 	// httprate.LimitBy(.., httprate.Key("*")).
 	//
-	// NOTE: middleware.GetClientIP returns the full client IP. To stop IPv6
-	// clients from rotating within their /64 to win fresh buckets, canonicalize
-	// the IP to /64 — see "Rate limit by client IP behind a proxy" below and
-	// _example/main.go.
-	//
 	// Please see _example/main.go for more, or read the library code.
 	r.Use(middleware.ClientIPFromRemoteAddr)
-	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+	r.Use(httprate.LimitBy(100, time.Minute, func(r *http.Request) (string, error) {
+		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
+	}))
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("."))
@@ -96,13 +95,10 @@ client-supplied header blindly is exactly the spoofing bug behind the deprecated
 
 Use chi's [`middleware.ClientIPFrom*`](https://pkg.go.dev/github.com/go-chi/chi/v5/middleware#ClientIPFromXFF)
 middlewares (chi `v5.3.0+`) to resolve a trusted client IP, then rate-limit by
-it with `LimitBy` + `KeyFromContext`:
+it with a `LimitBy` `KeyFunc` that reads it back and canonicalizes it:
 
 ```go
 import (
-	"context"
-	"net/netip"
-
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/httprate"
 )
@@ -112,35 +108,23 @@ import (
 r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
 
 // 2. Rate-limit by that trusted client IP.
-r.Use(httprate.LimitBy(100, time.Minute,
-	httprate.KeyFromContext(clientIPKey),
-))
+r.Use(httprate.LimitBy(100, time.Minute, clientIPKey))
 
-// clientIPKey reads the trusted client IP resolved in step 1 and canonicalizes
-// it for rate-limiting. chi's middleware.GetClientIPAddr returns the *full*
-// client IP as a net/netip.Addr; we bucket IPv6 clients by their /64 prefix so
-// a client can't rotate within its own /64 (2^64 addresses via SLAAC) to win a
-// fresh bucket on every request. IPv4 is used as-is.
-func clientIPKey(ctx context.Context) string {
-	ip := middleware.GetClientIPAddr(ctx)
-	if !ip.IsValid() {
-		return "" // no ClientIPFrom* upstream — see the note below
-	}
-	if ip.Is4() {
-		return ip.String()
-	}
-	return netip.PrefixFrom(ip, 64).Masked().Addr().String() // IPv6 → /64
+// clientIPKey is the rate-limit key. middleware.GetClientIP reads the IP
+// resolved in step 1; httprate.CanonicalizeIP buckets IPv6 clients by /64.
+func clientIPKey(r *http.Request) (string, error) {
+	return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
 }
 ```
 
 > [!NOTE]
-> Rate-limiting by the full IPv6 address (`KeyFromContext(middleware.GetClientIP)`)
-> lets an IPv6 client rotate within its own `/64` to get a fresh bucket per
-> request and bypass the limit. The `clientIPKey` helper above buckets IPv6 by
-> `/64` — adjust the prefix (e.g. `/56`, `/48`) if your clients are delegated a
-> larger block. The deprecated `KeyByIP` / `KeyByRealIP` did this `/64`
-> canonicalization for you; the explicit helper keeps it while making the trust
-> model and prefix your choice.
+> `middleware.GetClientIP` returns the *full* client IP. Keying on it directly
+> lets an IPv6 client rotate within its own `/64` (2^64 addresses via SLAAC) to
+> get a fresh bucket per request and bypass the limit. `httprate.CanonicalizeIP`
+> buckets IPv6 by `/64` (IPv4 unchanged) — copy its logic and widen the prefix
+> (e.g. `/56`, `/48`) if your clients are delegated a larger block. The
+> deprecated `KeyByIP` / `KeyByRealIP` did this canonicalization for you;
+> `CanonicalizeIP` keeps it while making the trust model and prefix your choice.
 
 Pick the one `ClientIPFrom*` middleware that matches how requests reach you:
 
@@ -161,17 +145,17 @@ for the full picker.
 > you'll trip the limit after `requestLimit` total requests in dev. Make sure
 > exactly one `ClientIPFrom*` middleware runs before the limiter.
 
-`KeyFromContext` is generic over `func(context.Context) string`, so it isn't
-tied to chi — pass your own extractor for echo, fiber, gin, or custom
-middleware that stashes the client IP (or tenant/user ID) in the request
-context.
+A `KeyFunc` is just `func(r *http.Request) (string, error)`, so it isn't tied to
+chi — read the client IP (or tenant/user ID) from wherever echo, fiber, gin, or
+your own middleware stashes it on the request, and return it.
 
 ### Rate limit by IP and URL path (aka endpoint)
 ```go
+// clientIPKey is the KeyFunc from "Rate limit by client IP behind a proxy" above.
 r.Use(httprate.LimitBy(
 	10,             // requests
 	10*time.Second, // per duration
-	httprate.JoinKeys(httprate.KeyFromContext(middleware.GetClientIP), httprate.KeyByEndpoint),
+	httprate.JoinKeys(clientIPKey, httprate.KeyByEndpoint),
 ))
 ```
 
@@ -220,7 +204,7 @@ The default response is `HTTP 429` with `Too Many Requests` body. You can overri
 r.Use(httprate.LimitBy(
 	10,
 	time.Minute,
-	httprate.KeyFromContext(middleware.GetClientIP),
+	clientIPKey, // the KeyFunc from "Rate limit by client IP behind a proxy" above
 	httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error": "Rate-limited. Please, slow down."}`, http.StatusTooManyRequests)
 	}),
@@ -239,7 +223,7 @@ An error can be returned by:
 r.Use(httprate.LimitBy(
 	10,
 	time.Minute,
-	httprate.KeyFromContext(middleware.GetClientIP),
+	clientIPKey, // the KeyFunc from "Rate limit by client IP behind a proxy" above
 	httprate.WithErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
 		http.Error(w, fmt.Sprintf(`{"error": %q}`, err), http.StatusPreconditionRequired)
 	}),
@@ -253,7 +237,7 @@ r.Use(httprate.LimitBy(
 r.Use(httprate.LimitBy(
 	1000,
 	time.Minute,
-	httprate.KeyFromContext(middleware.GetClientIP),
+	clientIPKey, // the KeyFunc from "Rate limit by client IP behind a proxy" above
 	httprate.WithResponseHeaders(httprate.ResponseHeaders{
 		Limit:      "X-RateLimit-Limit",
 		Remaining:  "X-RateLimit-Remaining",
@@ -270,7 +254,7 @@ r.Use(httprate.LimitBy(
 r.Use(httprate.LimitBy(
 	1000,
 	time.Minute,
-	httprate.KeyFromContext(middleware.GetClientIP),
+	clientIPKey, // the KeyFunc from "Rate limit by client IP behind a proxy" above
 	httprate.WithResponseHeaders(httprate.ResponseHeaders{}),
 ))
 ```

--- a/_example/client_ip_test.go
+++ b/_example/client_ip_test.go
@@ -3,12 +3,27 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/httprate"
 )
+
+// clientIPKey mirrors the inline rate-limit key funcs in main.go: the trusted
+// client IP resolved by an upstream middleware.ClientIPFrom*, with IPv6 bucketed
+// to its /64. Shared here so each test exercises the exact key the example uses.
+func clientIPKey(r *http.Request) (string, error) {
+	ip := middleware.GetClientIPAddr(r.Context())
+	if !ip.IsValid() {
+		return "", nil
+	}
+	if ip.Is4() {
+		return ip.String(), nil
+	}
+	return netip.PrefixFrom(ip, 64).Masked().Addr().String(), nil // IPv6 → /64
+}
 
 // These are integration tests for the safe client-IP rate-limiting pattern:
 // chi's middleware.ClientIPFrom* resolves a trusted client IP into the request
@@ -23,7 +38,7 @@ import (
 func TestLimitByClientIP_RemoteAddr(t *testing.T) {
 	h := chain(
 		middleware.ClientIPFromRemoteAddr,
-		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
+		httprate.LimitBy(2, time.Minute, clientIPKey),
 		okHandler(),
 	)
 
@@ -43,7 +58,7 @@ func TestLimitByClientIP_RemoteAddr(t *testing.T) {
 func TestLimitByClientIP_IPv6Bucket(t *testing.T) {
 	h := chain(
 		middleware.ClientIPFromRemoteAddr,
-		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
+		httprate.LimitBy(2, time.Minute, clientIPKey),
 		okHandler(),
 	)
 
@@ -83,7 +98,7 @@ func TestLimitByClientIP_IPv6Bucket(t *testing.T) {
 func TestLimitByClientIP_SpoofedXFF(t *testing.T) {
 	h := chain(
 		middleware.ClientIPFromXFF("10.0.0.0/8"),
-		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
+		httprate.LimitBy(2, time.Minute, clientIPKey),
 		okHandler(),
 	)
 
@@ -117,7 +132,7 @@ func TestLimitByClientIP_SpoofedXFF(t *testing.T) {
 func TestLimitByClientIP_Misconfig(t *testing.T) {
 	h := chain(
 		// No middleware.ClientIPFrom* installed on purpose.
-		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
+		httprate.LimitBy(2, time.Minute, clientIPKey),
 		okHandler(),
 	)
 

--- a/_example/client_ip_test.go
+++ b/_example/client_ip_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/netip"
 	"testing"
 	"time"
 
@@ -12,17 +11,11 @@ import (
 )
 
 // clientIPKey mirrors the inline rate-limit key funcs in main.go: the trusted
-// client IP resolved by an upstream middleware.ClientIPFrom*, with IPv6 bucketed
-// to its /64. Shared here so each test exercises the exact key the example uses.
+// client IP resolved by an upstream middleware.ClientIPFrom*, canonicalized
+// with httprate.CanonicalizeIP (IPv6 bucketed to /64). Shared here so each test
+// exercises the exact key the example uses.
 func clientIPKey(r *http.Request) (string, error) {
-	ip := middleware.GetClientIPAddr(r.Context())
-	if !ip.IsValid() {
-		return "", nil
-	}
-	if ip.Is4() {
-		return ip.String(), nil
-	}
-	return netip.PrefixFrom(ip, 64).Masked().Addr().String(), nil // IPv6 → /64
+	return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
 }
 
 // These are integration tests for the safe client-IP rate-limiting pattern:

--- a/_example/client_ip_test.go
+++ b/_example/client_ip_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/httprate"
+)
+
+// These are integration tests for the safe client-IP rate-limiting pattern:
+// chi's middleware.ClientIPFrom* resolves a trusted client IP into the request
+// context, and httprate.LimitBy(..., KeyFromContext(middleware.GetClientIP))
+// rate-limits by it. They live in the _example module on purpose so the main
+// httprate go.mod stays chi-free — chi is only a dependency of this example.
+
+// TestLimitByClientIP_RemoteAddr is the happy path: a server directly on the
+// internet uses middleware.ClientIPFromRemoteAddr upstream and rate-limits by
+// the resolved client IP. The same RemoteAddr is limited after requestLimit
+// requests.
+func TestLimitByClientIP_RemoteAddr(t *testing.T) {
+	h := chain(
+		middleware.ClientIPFromRemoteAddr,
+		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)),
+		okHandler(),
+	)
+
+	// Same client: 3rd request is blocked.
+	assertCodes(t, h, requestsFrom("1.2.3.4:1111", 3), []int{200, 200, 429})
+
+	// A different client gets its own bucket.
+	assertCodes(t, h, requestsFrom("5.6.7.8:2222", 1), []int{200})
+}
+
+// TestLimitByClientIP_SpoofedXFF is the fix-in-action test. The server sits
+// behind a trusted proxy in 10.0.0.0/8 (ClientIPFromXFF). An attacker at
+// 203.0.113.5 prepends a forged X-Forwarded-For value on every request, hoping
+// to rotate their rate-limit key and evade the limit. But the trusted proxy
+// always appends the attacker's real IP (203.0.113.5) as the rightmost XFF
+// entry, and ClientIPFromXFF resolves the rightmost non-trusted IP — so the key
+// stays 203.0.113.5 no matter what the attacker forges. The 3rd request is
+// blocked. This is the test that proves the GHSA is closed.
+func TestLimitByClientIP_SpoofedXFF(t *testing.T) {
+	h := chain(
+		middleware.ClientIPFromXFF("10.0.0.0/8"),
+		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)),
+		okHandler(),
+	)
+
+	codes := make([]int, 0, 3)
+	for _, spoof := range []string{"1.2.3.4", "9.9.9.9", "8.8.8.8"} {
+		req := httptest.NewRequest("GET", "/", nil)
+		// RemoteAddr is the trusted proxy; the proxy appended the attacker's
+		// real IP (203.0.113.5) to whatever XFF value the attacker forged.
+		req.RemoteAddr = "10.0.0.1:80"
+		req.Header.Set("X-Forwarded-For", spoof+", 203.0.113.5")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		codes = append(codes, rec.Result().StatusCode)
+	}
+	wantCodes(t, codes, []int{200, 200, 429})
+
+	// Sanity check the contrast: with the spoofable KeyByRealIP, rotating the
+	// forged header would have yielded a fresh key each time (no 429), which is
+	// exactly the evasion this fix prevents.
+	spoofedKey, _ := httprate.KeyByRealIP(mustReq("10.0.0.1:80", "1.2.3.4, 203.0.113.5"))
+	if spoofedKey != "1.2.3.4" {
+		t.Fatalf("sanity: KeyByRealIP = %q, want spoofed %q", spoofedKey, "1.2.3.4")
+	}
+}
+
+// TestLimitByClientIP_Misconfig documents the silent-global-bucket footgun: if
+// no ClientIPFrom* middleware is installed, GetClientIP returns "" for every
+// request, so all clients share a single bucket. This is strictly more
+// restrictive (never less), so it is a developer footgun, not a security
+// regression.
+func TestLimitByClientIP_Misconfig(t *testing.T) {
+	h := chain(
+		// No middleware.ClientIPFrom* installed on purpose.
+		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)),
+		okHandler(),
+	)
+
+	// Three requests from three different sources with different spoofed XFFs
+	// still share one bucket: the 3rd is blocked regardless of source.
+	codes := make([]int, 0, 3)
+	srcs := []string{"1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"}
+	for _, src := range srcs {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = src
+		req.Header.Set("X-Forwarded-For", src)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		codes = append(codes, rec.Result().StatusCode)
+	}
+	wantCodes(t, codes, []int{200, 200, 429})
+}
+
+// chain composes the given middlewares around a final handler, outermost first.
+func chain(parts ...interface{}) http.Handler {
+	if len(parts) == 0 {
+		return http.NotFoundHandler()
+	}
+	h, ok := parts[len(parts)-1].(http.Handler)
+	if !ok {
+		panic("chain: last element must be an http.Handler")
+	}
+	for i := len(parts) - 2; i >= 0; i-- {
+		mw, ok := parts[i].(func(http.Handler) http.Handler)
+		if !ok {
+			panic("chain: middleware must be func(http.Handler) http.Handler")
+		}
+		h = mw(h)
+	}
+	return h
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func mustReq(remoteAddr, xff string) *http.Request {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("X-Forwarded-For", xff)
+	return req
+}
+
+func requestsFrom(remoteAddr string, n int) []*http.Request {
+	reqs := make([]*http.Request, n)
+	for i := range reqs {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = remoteAddr
+		reqs[i] = req
+	}
+	return reqs
+}
+
+func assertCodes(t *testing.T, h http.Handler, reqs []*http.Request, want []int) {
+	t.Helper()
+	got := make([]int, len(reqs))
+	for i, req := range reqs {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		got[i] = rec.Result().StatusCode
+	}
+	wantCodes(t, got, want)
+}
+
+func wantCodes(t *testing.T, got, want []int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("status codes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("status code[%d] = %d, want %d (full: got %v, want %v)", i, got[i], want[i], got, want)
+		}
+	}
+}

--- a/_example/client_ip_test.go
+++ b/_example/client_ip_test.go
@@ -23,7 +23,7 @@ import (
 func TestLimitByClientIP_RemoteAddr(t *testing.T) {
 	h := chain(
 		middleware.ClientIPFromRemoteAddr,
-		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)),
+		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
 		okHandler(),
 	)
 
@@ -32,6 +32,44 @@ func TestLimitByClientIP_RemoteAddr(t *testing.T) {
 
 	// A different client gets its own bucket.
 	assertCodes(t, h, requestsFrom("5.6.7.8:2222", 1), []int{200})
+}
+
+// TestLimitByClientIP_IPv6Bucket proves clientIPKey buckets IPv6 clients by
+// their /64: addresses that differ only within the /64 share one bucket, so a
+// client cannot rotate within its own /64 (trivial with SLAAC) to win fresh
+// rate-limit buckets. A different /64 gets its own bucket. Without the /64
+// canonicalization, GetClientIP returns the full address and each of these
+// would be a separate key — the bypass this guards against.
+func TestLimitByClientIP_IPv6Bucket(t *testing.T) {
+	h := chain(
+		middleware.ClientIPFromRemoteAddr,
+		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
+		okHandler(),
+	)
+
+	// Three addresses in the same /64: the 3rd is blocked.
+	codes := make([]int, 0, 3)
+	for _, addr := range []string{
+		"[2001:db8:abcd:1234::1]:5555",
+		"[2001:db8:abcd:1234:ffff::2]:6666",
+		"[2001:db8:abcd:1234::3]:7777",
+	} {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = addr
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		codes = append(codes, rec.Result().StatusCode)
+	}
+	wantCodes(t, codes, []int{200, 200, 429})
+
+	// A different /64 has its own bucket.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "[2001:db8:abcd:5678::1]:8888"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if code := rec.Result().StatusCode; code != 200 {
+		t.Fatalf("different /64 = %d, want 200 (separate bucket)", code)
+	}
 }
 
 // TestLimitByClientIP_SpoofedXFF is the fix-in-action test. The server sits
@@ -45,7 +83,7 @@ func TestLimitByClientIP_RemoteAddr(t *testing.T) {
 func TestLimitByClientIP_SpoofedXFF(t *testing.T) {
 	h := chain(
 		middleware.ClientIPFromXFF("10.0.0.0/8"),
-		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)),
+		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
 		okHandler(),
 	)
 
@@ -79,7 +117,7 @@ func TestLimitByClientIP_SpoofedXFF(t *testing.T) {
 func TestLimitByClientIP_Misconfig(t *testing.T) {
 	h := chain(
 		// No middleware.ClientIPFrom* installed on purpose.
-		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)),
+		httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(clientIPKey)),
 		okHandler(),
 	)
 

--- a/_example/go.mod
+++ b/_example/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 replace github.com/go-chi/httprate => ../
 
 require (
-	github.com/go-chi/chi/v5 v5.1.0
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/httprate v0.0.0-00010101000000-000000000000
 )
 

--- a/_example/go.sum
+++ b/_example/go.sum
@@ -1,5 +1,5 @@
-github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
-github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/_example/main.go
+++ b/_example/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"net/netip"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -23,21 +22,14 @@ func main() {
 	// resolved by middleware.ClientIPFromRemoteAddr. Behind a proxy, use
 	// ClientIPFromXFF / ClientIPFromHeader instead (see the /proxied route below).
 	//
-	// The key func reads the resolved IP with chi's middleware.GetClientIPAddr
-	// (a stdlib net/netip.Addr — the exact address) and buckets IPv6 clients by
-	// their /64: an IPv6 host typically owns a whole /64 (2^64 addresses via
-	// SLAAC), so without this a client could rotate within its own /64 to win a
-	// fresh bucket per request and bypass the limit. IPv4 is used as-is.
+	// The key func reads the resolved IP with chi's middleware.GetClientIP and
+	// canonicalizes it with httprate.CanonicalizeIP, which buckets IPv6 clients
+	// by their /64: an IPv6 host typically owns a whole /64 (2^64 addresses via
+	// SLAAC), so keying on the full address would let a client rotate within its
+	// own /64 to win a fresh bucket per request and bypass the limit.
 	r.Use(middleware.ClientIPFromRemoteAddr)
 	r.Use(httprate.LimitBy(1000, time.Minute, func(r *http.Request) (string, error) {
-		ip := middleware.GetClientIPAddr(r.Context())
-		if !ip.IsValid() {
-			return "", nil
-		}
-		if ip.Is4() {
-			return ip.String(), nil
-		}
-		return netip.PrefixFrom(ip, 64).Masked().Addr().String(), nil // IPv6 → /64
+		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
 	}))
 
 	// Rate-limit by the *trusted* client IP when running behind a reverse
@@ -55,14 +47,7 @@ func main() {
 	r.Route("/proxied", func(r chi.Router) {
 		r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
 		r.Use(httprate.LimitBy(100, time.Minute, func(r *http.Request) (string, error) {
-			ip := middleware.GetClientIPAddr(r.Context())
-			if !ip.IsValid() {
-				return "", nil
-			}
-			if ip.Is4() {
-				return ip.String(), nil
-			}
-			return netip.PrefixFrom(ip, 64).Masked().Addr().String(), nil // IPv6 → /64
+			return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
 		}))
 
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/_example/main.go
+++ b/_example/main.go
@@ -5,12 +5,38 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/httprate"
 )
+
+// clientIPKey is the rate-limit key: the trusted client IP resolved by whichever
+// middleware.ClientIPFrom* runs upstream, canonicalized for rate-limiting.
+//
+// chi's middleware.GetClientIPAddr returns the *full* client IP as a stdlib
+// net/netip.Addr (the exact address — right for logging and audit). For
+// rate-limiting we instead bucket IPv6 clients by their /64 prefix: an IPv6 host
+// typically owns a whole /64 (2^64 addresses via SLAAC), so without this a client
+// could rotate within its own /64 to win a fresh bucket on every request and
+// bypass the per-IP limit. IPv4 addresses are used as-is.
+//
+// Returns "" if no client IP was resolved (no ClientIPFrom* installed upstream);
+// every request then shares one global bucket — see the WARNING on
+// httprate.KeyFromContext.
+func clientIPKey(ctx context.Context) string {
+	ip := middleware.GetClientIPAddr(ctx)
+	if !ip.IsValid() {
+		return ""
+	}
+	if ip.Is4() {
+		return ip.String()
+	}
+	// IPv6: bucket by /64.
+	return netip.PrefixFrom(ip, 64).Masked().Addr().String()
+}
 
 func main() {
 	r := chi.NewRouter()
@@ -20,10 +46,11 @@ func main() {
 	// default IP source, so state the trust model explicitly: this server is
 	// directly exposed to clients, so the client IP is the TCP peer (RemoteAddr),
 	// resolved by middleware.ClientIPFromRemoteAddr and read via
-	// KeyFromContext(middleware.GetClientIP). Behind a proxy, use ClientIPFromXFF
-	// / ClientIPFromHeader instead (see the /proxied route below).
+	// KeyFromContext(clientIPKey) (which canonicalizes IPv6 to /64 — see
+	// clientIPKey below). Behind a proxy, use ClientIPFromXFF / ClientIPFromHeader
+	// instead (see the /proxied route below).
 	r.Use(middleware.ClientIPFromRemoteAddr)
-	r.Use(httprate.LimitBy(1000, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+	r.Use(httprate.LimitBy(1000, time.Minute, httprate.KeyFromContext(clientIPKey)))
 
 	// Rate-limit by the *trusted* client IP when running behind a reverse
 	// proxy / CDN. middleware.ClientIPFromXFF resolves the client IP from the
@@ -39,7 +66,7 @@ func main() {
 	r.Route("/proxied", func(r chi.Router) {
 		r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
 		r.Use(httprate.LimitBy(100, time.Minute,
-			httprate.KeyFromContext(middleware.GetClientIP),
+			httprate.KeyFromContext(clientIPKey),
 		))
 
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/_example/main.go
+++ b/_example/main.go
@@ -13,31 +13,6 @@ import (
 	"github.com/go-chi/httprate"
 )
 
-// clientIPKey is the rate-limit key: the trusted client IP resolved by whichever
-// middleware.ClientIPFrom* runs upstream, canonicalized for rate-limiting.
-//
-// chi's middleware.GetClientIPAddr returns the *full* client IP as a stdlib
-// net/netip.Addr (the exact address — right for logging and audit). For
-// rate-limiting we instead bucket IPv6 clients by their /64 prefix: an IPv6 host
-// typically owns a whole /64 (2^64 addresses via SLAAC), so without this a client
-// could rotate within its own /64 to win a fresh bucket on every request and
-// bypass the per-IP limit. IPv4 addresses are used as-is.
-//
-// Returns "" if no client IP was resolved (no ClientIPFrom* installed upstream);
-// every request then shares one global bucket — see the WARNING on
-// httprate.KeyFromContext.
-func clientIPKey(ctx context.Context) string {
-	ip := middleware.GetClientIPAddr(ctx)
-	if !ip.IsValid() {
-		return ""
-	}
-	if ip.Is4() {
-		return ip.String()
-	}
-	// IPv6: bucket by /64.
-	return netip.PrefixFrom(ip, 64).Masked().Addr().String()
-}
-
 func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
@@ -45,17 +20,31 @@ func main() {
 	// Rate-limit all routes at 1000 req/min by client IP. There is no safe
 	// default IP source, so state the trust model explicitly: this server is
 	// directly exposed to clients, so the client IP is the TCP peer (RemoteAddr),
-	// resolved by middleware.ClientIPFromRemoteAddr and read via
-	// KeyFromContext(clientIPKey) (which canonicalizes IPv6 to /64 — see
-	// clientIPKey below). Behind a proxy, use ClientIPFromXFF / ClientIPFromHeader
-	// instead (see the /proxied route below).
+	// resolved by middleware.ClientIPFromRemoteAddr. Behind a proxy, use
+	// ClientIPFromXFF / ClientIPFromHeader instead (see the /proxied route below).
+	//
+	// The key func reads the resolved IP with chi's middleware.GetClientIPAddr
+	// (a stdlib net/netip.Addr — the exact address) and buckets IPv6 clients by
+	// their /64: an IPv6 host typically owns a whole /64 (2^64 addresses via
+	// SLAAC), so without this a client could rotate within its own /64 to win a
+	// fresh bucket per request and bypass the limit. IPv4 is used as-is.
 	r.Use(middleware.ClientIPFromRemoteAddr)
-	r.Use(httprate.LimitBy(1000, time.Minute, httprate.KeyFromContext(clientIPKey)))
+	r.Use(httprate.LimitBy(1000, time.Minute, func(r *http.Request) (string, error) {
+		ip := middleware.GetClientIPAddr(r.Context())
+		if !ip.IsValid() {
+			return "", nil
+		}
+		if ip.Is4() {
+			return ip.String(), nil
+		}
+		return netip.PrefixFrom(ip, 64).Masked().Addr().String(), nil // IPv6 → /64
+	}))
 
 	// Rate-limit by the *trusted* client IP when running behind a reverse
 	// proxy / CDN. middleware.ClientIPFromXFF resolves the client IP from the
 	// X-Forwarded-For chain, skipping the trusted proxy CIDR(s), and stashes it
-	// in the request context; KeyFromContext(middleware.GetClientIP) reads it.
+	// in the request context; the key func reads it back (same /64 bucketing as
+	// the root limiter above).
 	//
 	// This is the safe replacement for the deprecated, spoofable
 	// httprate.LimitByRealIP — a client can no longer forge X-Forwarded-For to
@@ -65,9 +54,16 @@ func main() {
 	// assume one trusted proxy in 10.0.0.0/8.
 	r.Route("/proxied", func(r chi.Router) {
 		r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
-		r.Use(httprate.LimitBy(100, time.Minute,
-			httprate.KeyFromContext(clientIPKey),
-		))
+		r.Use(httprate.LimitBy(100, time.Minute, func(r *http.Request) (string, error) {
+			ip := middleware.GetClientIPAddr(r.Context())
+			if !ip.IsValid() {
+				return "", nil
+			}
+			if ip.Is4() {
+				return ip.String(), nil
+			}
+			return netip.PrefixFrom(ip, 64).Masked().Addr().String(), nil // IPv6 → /64
+		}))
 
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("proxied: 100 req/min per trusted client IP\n"))

--- a/_example/main.go
+++ b/_example/main.go
@@ -16,8 +16,31 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 
-	// Rate-limit all routes at 1000 req/min by IP address.
-	r.Use(httprate.LimitByIP(1000, time.Minute))
+	// Rate-limit all routes at 1000 req/min by IP address (RemoteAddr, the TCP
+	// peer). Use this when the server is directly exposed to clients.
+	r.Use(httprate.LimitBy(1000, time.Minute, httprate.KeyByIP))
+
+	// Rate-limit by the *trusted* client IP when running behind a reverse
+	// proxy / CDN. middleware.ClientIPFromXFF resolves the client IP from the
+	// X-Forwarded-For chain, skipping the trusted proxy CIDR(s), and stashes it
+	// in the request context; KeyFromContext(middleware.GetClientIP) reads it.
+	//
+	// This is the safe replacement for the deprecated, spoofable
+	// httprate.LimitByRealIP — a client can no longer forge X-Forwarded-For to
+	// evade the limit or lock out another user.
+	//
+	// Pick the ClientIPFrom* middleware that matches your deployment; here we
+	// assume one trusted proxy in 10.0.0.0/8.
+	r.Route("/proxied", func(r chi.Router) {
+		r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+		r.Use(httprate.LimitBy(100, time.Minute,
+			httprate.KeyFromContext(middleware.GetClientIP),
+		))
+
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("proxied: 100 req/min per trusted client IP\n"))
+		})
+	})
 
 	r.Route("/admin", func(r chi.Router) {
 		r.Use(func(next http.Handler) http.Handler {
@@ -69,6 +92,7 @@ func main() {
 	log.Printf(`curl -v http://localhost:3333?[0-1000]`)
 	log.Printf(`curl -v http://localhost:3333/admin?[1-12]`)
 	log.Printf(`curl -v http://localhost:3333/login\?[1-8] --data '{"username":"alice","password":"***"}'`)
+	log.Printf(`curl -v -H 'X-Forwarded-For: 1.2.3.4, 203.0.113.5' http://localhost:3333/proxied?[1-102]`)
 
 	http.ListenAndServe(":3333", r)
 }

--- a/_example/main.go
+++ b/_example/main.go
@@ -16,9 +16,14 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 
-	// Rate-limit all routes at 1000 req/min by IP address (RemoteAddr, the TCP
-	// peer). Use this when the server is directly exposed to clients.
-	r.Use(httprate.LimitBy(1000, time.Minute, httprate.KeyByIP))
+	// Rate-limit all routes at 1000 req/min by client IP. There is no safe
+	// default IP source, so state the trust model explicitly: this server is
+	// directly exposed to clients, so the client IP is the TCP peer (RemoteAddr),
+	// resolved by middleware.ClientIPFromRemoteAddr and read via
+	// KeyFromContext(middleware.GetClientIP). Behind a proxy, use ClientIPFromXFF
+	// / ClientIPFromHeader instead (see the /proxied route below).
+	r.Use(middleware.ClientIPFromRemoteAddr)
+	r.Use(httprate.LimitBy(1000, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
 
 	// Rate-limit by the *trusted* client IP when running behind a reverse
 	// proxy / CDN. middleware.ClientIPFromXFF resolves the client IP from the

--- a/_example/main.go
+++ b/_example/main.go
@@ -51,12 +51,12 @@ func main() {
 		})
 
 		// Rate-limit admin routes at 10 req/s by userID.
-		r.Use(httprate.Limit(
+		r.Use(httprate.LimitBy(
 			10, time.Second,
-			httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
+			func(r *http.Request) (string, error) {
 				token, _ := r.Context().Value("userID").(string)
 				return token, nil
-			}),
+			},
 		))
 
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/client_ip_test.go
+++ b/client_ip_test.go
@@ -70,10 +70,10 @@ func TestKeyFromContext_EmptyKey(t *testing.T) {
 	wantCodes(t, codes, []int{200, 200, 429})
 }
 
-// TestComposeKeys verifies multi-dimensional rate-limiting: the same IP hitting
+// TestJoinKeys verifies multi-dimensional rate-limiting: the same IP hitting
 // two different endpoints gets two independent buckets.
-func TestComposeKeys(t *testing.T) {
-	h := httprate.LimitBy(1, time.Minute, httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint))(okHandler())
+func TestJoinKeys(t *testing.T) {
+	h := httprate.LimitBy(1, time.Minute, httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint))(okHandler())
 
 	get := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -94,16 +94,16 @@ func TestComposeKeys(t *testing.T) {
 	}
 }
 
-// TestComposeKeys_EmptyComponent verifies that an empty key component (e.g. an
+// TestJoinKeys_EmptyComponent verifies that an empty key component (e.g. an
 // unauthenticated request with no tenant) is passed through without error or
-// panic — the empty component just becomes part of the composed key.
-func TestComposeKeys_EmptyComponent(t *testing.T) {
+// panic — the empty component just becomes part of the joined key.
+func TestJoinKeys_EmptyComponent(t *testing.T) {
 	getTenant := func(ctx context.Context) string {
 		v, _ := ctx.Value("tenant").(string)
 		return v
 	}
 
-	h := httprate.LimitBy(2, time.Minute, httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyFromContext(getTenant)))(okHandler())
+	h := httprate.LimitBy(2, time.Minute, httprate.JoinKeys(httprate.KeyByIP, httprate.KeyFromContext(getTenant)))(okHandler())
 
 	// No "tenant" in context: empty component, no error, request still served.
 	assertCodes(t, h, requestsFrom("1.2.3.4:1111", 3), []int{200, 200, 429})

--- a/client_ip_test.go
+++ b/client_ip_test.go
@@ -10,19 +10,20 @@ import (
 	"github.com/go-chi/httprate"
 )
 
-// TestKeyFromContext verifies that LimitBy keys off the value the extractor
-// pulls from the request context: requests carrying the same value share a
-// bucket, different values get their own.
+// TestKeyFunc_FromContext verifies that LimitBy keys off whatever a KeyFunc
+// reads from the request context: requests carrying the same value share a
+// bucket, different values get their own. A KeyFunc receives *http.Request, so
+// it reads r.Context() directly — no special context helper needed.
 //
 // Integration with chi's middleware.ClientIPFrom* / middleware.GetClientIP
 // lives in _example/client_ip_test.go so the main module stays chi-free.
-func TestKeyFromContext(t *testing.T) {
+func TestKeyFunc_FromContext(t *testing.T) {
 	type ctxKey string
 	const tenantKey ctxKey = "tenant"
 
-	extractor := func(ctx context.Context) string {
-		v, _ := ctx.Value(tenantKey).(string)
-		return v
+	keyByTenant := func(r *http.Request) (string, error) {
+		v, _ := r.Context().Value(tenantKey).(string)
+		return v, nil
 	}
 
 	withTenant := func(tenant string, next http.Handler) http.Handler {
@@ -31,7 +32,7 @@ func TestKeyFromContext(t *testing.T) {
 		})
 	}
 
-	limiter := httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(extractor))
+	limiter := httprate.LimitBy(2, time.Minute, keyByTenant)
 
 	get := func(tenant string) int {
 		h := withTenant(tenant, limiter(okHandler()))
@@ -49,14 +50,14 @@ func TestKeyFromContext(t *testing.T) {
 	}
 }
 
-// TestKeyFromContext_EmptyKey documents the silent-global-bucket footgun: when
-// the extractor returns "" (e.g. the upstream middleware that should populate
-// the context was not installed), every request shares one bucket. Strictly
-// more restrictive, not a security regression.
-func TestKeyFromContext_EmptyKey(t *testing.T) {
-	emptyExtractor := func(ctx context.Context) string { return "" }
+// TestKeyFunc_EmptyKey documents the silent-global-bucket footgun: when the
+// KeyFunc returns "" (e.g. the upstream middleware that should populate the
+// context was not installed), every request shares one bucket. Strictly more
+// restrictive, not a security regression.
+func TestKeyFunc_EmptyKey(t *testing.T) {
+	emptyKey := func(r *http.Request) (string, error) { return "", nil }
 
-	h := httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(emptyExtractor))(okHandler())
+	h := httprate.LimitBy(2, time.Minute, emptyKey)(okHandler())
 
 	// Three different sources still share one bucket; the 3rd is blocked.
 	codes := make([]int, 0, 3)
@@ -98,12 +99,12 @@ func TestJoinKeys(t *testing.T) {
 // unauthenticated request with no tenant) is passed through without error or
 // panic — the empty component just becomes part of the joined key.
 func TestJoinKeys_EmptyComponent(t *testing.T) {
-	getTenant := func(ctx context.Context) string {
-		v, _ := ctx.Value("tenant").(string)
-		return v
+	keyByTenant := func(r *http.Request) (string, error) {
+		v, _ := r.Context().Value("tenant").(string)
+		return v, nil
 	}
 
-	h := httprate.LimitBy(2, time.Minute, httprate.JoinKeys(httprate.KeyByIP, httprate.KeyFromContext(getTenant)))(okHandler())
+	h := httprate.LimitBy(2, time.Minute, httprate.JoinKeys(httprate.KeyByIP, keyByTenant))(okHandler())
 
 	// No "tenant" in context: empty component, no error, request still served.
 	assertCodes(t, h, requestsFrom("1.2.3.4:1111", 3), []int{200, 200, 429})

--- a/client_ip_test.go
+++ b/client_ip_test.go
@@ -1,0 +1,169 @@
+package httprate_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/httprate"
+)
+
+// TestKeyFromContext verifies that LimitBy keys off the value the extractor
+// pulls from the request context: requests carrying the same value share a
+// bucket, different values get their own.
+//
+// Integration with chi's middleware.ClientIPFrom* / middleware.GetClientIP
+// lives in _example/client_ip_test.go so the main module stays chi-free.
+func TestKeyFromContext(t *testing.T) {
+	type ctxKey string
+	const tenantKey ctxKey = "tenant"
+
+	extractor := func(ctx context.Context) string {
+		v, _ := ctx.Value(tenantKey).(string)
+		return v
+	}
+
+	withTenant := func(tenant string, next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), tenantKey, tenant)))
+		})
+	}
+
+	limiter := httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(extractor))
+
+	get := func(tenant string) int {
+		h := withTenant(tenant, limiter(okHandler()))
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec.Result().StatusCode
+	}
+
+	// Same tenant trips the limit on the 3rd request.
+	wantCodes(t, []int{get("acme"), get("acme"), get("acme")}, []int{200, 200, 429})
+	// A different tenant has its own bucket.
+	if code := get("globex"); code != 200 {
+		t.Fatalf("different tenant = %d, want 200 (separate bucket)", code)
+	}
+}
+
+// TestKeyFromContext_EmptyKey documents the silent-global-bucket footgun: when
+// the extractor returns "" (e.g. the upstream middleware that should populate
+// the context was not installed), every request shares one bucket. Strictly
+// more restrictive, not a security regression.
+func TestKeyFromContext_EmptyKey(t *testing.T) {
+	emptyExtractor := func(ctx context.Context) string { return "" }
+
+	h := httprate.LimitBy(2, time.Minute, httprate.KeyFromContext(emptyExtractor))(okHandler())
+
+	// Three different sources still share one bucket; the 3rd is blocked.
+	codes := make([]int, 0, 3)
+	for _, src := range []string{"1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"} {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = src
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		codes = append(codes, rec.Result().StatusCode)
+	}
+	wantCodes(t, codes, []int{200, 200, 429})
+}
+
+// TestComposeKeys verifies multi-dimensional rate-limiting: the same IP hitting
+// two different endpoints gets two independent buckets.
+func TestComposeKeys(t *testing.T) {
+	h := httprate.LimitBy(1, time.Minute, httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint))(okHandler())
+
+	get := func(path string) int {
+		req := httptest.NewRequest("GET", path, nil)
+		req.RemoteAddr = "1.2.3.4:1111"
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec.Result().StatusCode
+	}
+
+	if code := get("/a"); code != 200 {
+		t.Fatalf("GET /a #1 = %d, want 200", code)
+	}
+	if code := get("/b"); code != 200 {
+		t.Fatalf("GET /b #1 = %d, want 200 (different endpoint, separate bucket)", code)
+	}
+	if code := get("/a"); code != 429 {
+		t.Fatalf("GET /a #2 = %d, want 429 (same IP+endpoint bucket exhausted)", code)
+	}
+}
+
+// TestComposeKeys_EmptyComponent verifies that an empty key component (e.g. an
+// unauthenticated request with no tenant) is passed through without error or
+// panic — the empty component just becomes part of the composed key.
+func TestComposeKeys_EmptyComponent(t *testing.T) {
+	getTenant := func(ctx context.Context) string {
+		v, _ := ctx.Value("tenant").(string)
+		return v
+	}
+
+	h := httprate.LimitBy(2, time.Minute, httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyFromContext(getTenant)))(okHandler())
+
+	// No "tenant" in context: empty component, no error, request still served.
+	assertCodes(t, h, requestsFrom("1.2.3.4:1111", 3), []int{200, 200, 429})
+}
+
+// TestKeyByRealIP_SpoofableRegression documents the deprecated, spoofable
+// behavior of KeyByRealIP: a client-supplied True-Client-IP header dictates the
+// rate-limit key with no proxy-trust check. This is exactly why KeyByRealIP,
+// WithKeyByRealIP, and LimitByRealIP are deprecated (GHSA-9g5q-2w5x-hmxf,
+// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx). Kept so future archaeologists
+// understand the deprecation.
+func TestKeyByRealIP_SpoofableRegression(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.5:4444"
+	req.Header.Set("True-Client-IP", "1.2.3.4")
+
+	key, err := httprate.KeyByRealIP(req)
+	if err != nil {
+		t.Fatalf("KeyByRealIP returned error: %v", err)
+	}
+	if key != "1.2.3.4" {
+		t.Fatalf("KeyByRealIP = %q, want %q (spoofed header trusted — the deprecated behavior)", key, "1.2.3.4")
+	}
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func requestsFrom(remoteAddr string, n int) []*http.Request {
+	reqs := make([]*http.Request, n)
+	for i := range reqs {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = remoteAddr
+		reqs[i] = req
+	}
+	return reqs
+}
+
+func assertCodes(t *testing.T, h http.Handler, reqs []*http.Request, want []int) {
+	t.Helper()
+	got := make([]int, len(reqs))
+	for i, req := range reqs {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		got[i] = rec.Result().StatusCode
+	}
+	wantCodes(t, got, want)
+}
+
+func wantCodes(t *testing.T, got, want []int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("status codes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("status code[%d] = %d, want %d (full: got %v, want %v)", i, got[i], want[i], got, want)
+		}
+	}
+}

--- a/deprecated.go
+++ b/deprecated.go
@@ -14,9 +14,9 @@ import (
 
 // Deprecated: Use LimitBy(requestLimit, windowLength, keyFn, options...) instead,
 // which makes the rate-limit key an explicit, required argument rather than an
-// optional WithKeyFuncs. Pass the key function directly (e.g.
-// KeyFromContext(middleware.GetClientIP) for a trusted client IP), or
-// httprate.Key("*") for a single global bucket. The remaining options
+// optional WithKeyFuncs. Pass the key function directly (e.g. a KeyFunc that
+// reads a trusted client IP — see CanonicalizeIP), or httprate.Key("*") for a
+// single global bucket. The remaining options
 // (WithLimitCounter, WithLimitHandler, WithResponseHeaders, ...) carry over
 // unchanged as LimitBy's trailing variadic.
 func Limit(requestLimit int, windowLength time.Duration, options ...Option) func(next http.Handler) http.Handler {
@@ -36,11 +36,13 @@ func LimitAll(requestLimit int, windowLength time.Duration) func(next http.Handl
 // the proxy's address, so every client sharing that proxy lands in one bucket —
 // usually the wrong key in production. State your trust model explicitly:
 // install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
-// use LimitBy with KeyFromContext(middleware.GetClientIP):
+// key off the resolved IP (CanonicalizeIP buckets IPv6 by /64):
 //
 //	// Directly exposed to clients (LimitByIP's exact behavior, made explicit):
 //	r.Use(middleware.ClientIPFromRemoteAddr)
-//	r.Use(httprate.LimitBy(requestLimit, windowLength, httprate.KeyFromContext(middleware.GetClientIP)))
+//	r.Use(httprate.LimitBy(requestLimit, windowLength, func(r *http.Request) (string, error) {
+//		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
+//	}))
 func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
 	return LimitBy(requestLimit, windowLength, KeyByIP)
 }
@@ -49,10 +51,13 @@ func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Hand
 // remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
 // GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
 // middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
-// (chi v5.3.0+) and use LimitBy with KeyFromContext instead:
+// (chi v5.3.0+) and key off the resolved IP instead (CanonicalizeIP buckets
+// IPv6 by /64):
 //
 //	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
-//	r.Use(httprate.LimitBy(requestLimit, windowLength, httprate.KeyFromContext(middleware.GetClientIP)))
+//	r.Use(httprate.LimitBy(requestLimit, windowLength, func(r *http.Request) (string, error) {
+//		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
+//	}))
 func LimitByRealIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
 	return LimitBy(requestLimit, windowLength, KeyByRealIP)
 }
@@ -66,10 +71,12 @@ func LimitByRealIP(requestLimit int, windowLength time.Duration) func(next http.
 // out by pinning the header to the victim's IP (exhausting their bucket).
 //
 // Install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
-// use KeyFromContext(middleware.GetClientIP) instead:
+// key off the resolved IP instead (CanonicalizeIP buckets IPv6 by /64):
 //
 //	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
-//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+//	r.Use(httprate.LimitBy(100, time.Minute, func(r *http.Request) (string, error) {
+//		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
+//	}))
 func KeyByRealIP(r *http.Request) (string, error) {
 	var ip string
 
@@ -91,15 +98,15 @@ func KeyByRealIP(r *http.Request) (string, error) {
 		}
 	}
 
-	return canonicalizeIP(ip), nil
+	return CanonicalizeIP(ip), nil
 }
 
 // Deprecated: WithKeyByRealIP installs the spoofable KeyByRealIP and lets a
 // remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
 // GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
 // middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
-// (chi v5.3.0+) and use LimitBy with KeyFromContext(middleware.GetClientIP)
-// instead.
+// (chi v5.3.0+) and key off the resolved IP with LimitBy instead (see
+// CanonicalizeIP).
 func WithKeyByRealIP() Option {
 	return WithKeyFuncs(KeyByRealIP)
 }
@@ -112,11 +119,14 @@ func WithKeyByRealIP() Option {
 // production, and there is no safe default IP source.
 //
 // State your trust model explicitly with one of chi's middleware.ClientIPFrom*
-// middlewares (chi v5.3.0+) and read it with KeyFromContext(middleware.GetClientIP):
+// middlewares (chi v5.3.0+) and key off the resolved IP (CanonicalizeIP buckets
+// IPv6 by /64):
 //
 //	// Directly exposed to clients (KeyByIP's exact behavior, made explicit):
 //	r.Use(middleware.ClientIPFromRemoteAddr)
-//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+//	r.Use(httprate.LimitBy(100, time.Minute, func(r *http.Request) (string, error) {
+//		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
+//	}))
 //
 //	// Behind a proxy: use ClientIPFromXFF / ClientIPFromHeader / ... instead.
 //
@@ -126,7 +136,7 @@ func KeyByIP(r *http.Request) (string, error) {
 	if err != nil {
 		ip = r.RemoteAddr
 	}
-	return canonicalizeIP(ip), nil
+	return CanonicalizeIP(ip), nil
 }
 
 // Deprecated: WithKeyByIP installs KeyByIP, which keys off r.RemoteAddr — the
@@ -134,42 +144,7 @@ func KeyByIP(r *http.Request) (string, error) {
 // the wrong key in production (see KeyByIP). It is not a spoofing issue, but
 // there is no safe default IP source. State your trust model explicitly:
 // install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
-// use LimitBy with KeyFromContext(middleware.GetClientIP) instead.
+// key off the resolved IP with LimitBy instead (see CanonicalizeIP).
 func WithKeyByIP() Option {
 	return WithKeyFuncs(KeyByIP)
-}
-
-// canonicalizeIP returns a form of ip suitable for comparison to other IPs.
-// For IPv4 addresses, this is simply the whole string.
-// For IPv6 addresses, this is the /64 prefix.
-//
-// Only used by the deprecated KeyByIP / KeyByRealIP above. The supported
-// client-IP path (chi's middleware.ClientIPFrom* + KeyFromContext) canonicalizes
-// the IP upstream, so httprate no longer needs this for new code.
-func canonicalizeIP(ip string) string {
-	isIPv6 := false
-	// This is how net.ParseIP decides if an address is IPv6
-	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/net/ip.go;l=704
-	for i := 0; !isIPv6 && i < len(ip); i++ {
-		switch ip[i] {
-		case '.':
-			// IPv4
-			return ip
-		case ':':
-			// IPv6
-			isIPv6 = true
-			break
-		}
-	}
-	if !isIPv6 {
-		// Not an IP address at all
-		return ip
-	}
-
-	ipv6 := net.ParseIP(ip)
-	if ipv6 == nil {
-		return ip
-	}
-
-	return ipv6.Mask(net.CIDRMask(64, 128)).String()
 }

--- a/deprecated.go
+++ b/deprecated.go
@@ -14,8 +14,9 @@ import (
 
 // Deprecated: Use LimitBy(requestLimit, windowLength, keyFn, options...) instead,
 // which makes the rate-limit key an explicit, required argument rather than an
-// optional WithKeyFuncs. Pass the key function directly (e.g. httprate.KeyByIP),
-// or httprate.Key("*") for a single global bucket. The remaining options
+// optional WithKeyFuncs. Pass the key function directly (e.g.
+// KeyFromContext(middleware.GetClientIP) for a trusted client IP), or
+// httprate.Key("*") for a single global bucket. The remaining options
 // (WithLimitCounter, WithLimitHandler, WithResponseHeaders, ...) carry over
 // unchanged as LimitBy's trailing variadic.
 func Limit(requestLimit int, windowLength time.Duration, options ...Option) func(next http.Handler) http.Handler {
@@ -30,8 +31,16 @@ func LimitAll(requestLimit int, windowLength time.Duration) func(next http.Handl
 	return LimitBy(requestLimit, windowLength, Key("*"))
 }
 
-// Deprecated: Use LimitBy(requestLimit, windowLength, KeyByIP) instead. This is
-// an ergonomic rename with identical behavior, not a security fix.
+// Deprecated: LimitByIP keys off r.RemoteAddr (see KeyByIP). It is not
+// spoofable, but behind a reverse proxy, load balancer, or CDN r.RemoteAddr is
+// the proxy's address, so every client sharing that proxy lands in one bucket —
+// usually the wrong key in production. State your trust model explicitly:
+// install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
+// use LimitBy with KeyFromContext(middleware.GetClientIP):
+//
+//	// Directly exposed to clients (LimitByIP's exact behavior, made explicit):
+//	r.Use(middleware.ClientIPFromRemoteAddr)
+//	r.Use(httprate.LimitBy(requestLimit, windowLength, httprate.KeyFromContext(middleware.GetClientIP)))
 func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
 	return LimitBy(requestLimit, windowLength, KeyByIP)
 }
@@ -93,4 +102,74 @@ func KeyByRealIP(r *http.Request) (string, error) {
 // instead.
 func WithKeyByRealIP() Option {
 	return WithKeyFuncs(KeyByRealIP)
+}
+
+// Deprecated: KeyByIP keys off r.RemoteAddr, the TCP peer that opened the
+// connection. Unlike KeyByRealIP it is NOT spoofable (RemoteAddr is set by
+// net/http, never from a header) — but behind a reverse proxy, load balancer,
+// or CDN, r.RemoteAddr is the proxy's address, so every client sharing that
+// proxy lands in one rate-limit bucket. That's usually the wrong key in
+// production, and there is no safe default IP source.
+//
+// State your trust model explicitly with one of chi's middleware.ClientIPFrom*
+// middlewares (chi v5.3.0+) and read it with KeyFromContext(middleware.GetClientIP):
+//
+//	// Directly exposed to clients (KeyByIP's exact behavior, made explicit):
+//	r.Use(middleware.ClientIPFromRemoteAddr)
+//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+//
+//	// Behind a proxy: use ClientIPFromXFF / ClientIPFromHeader / ... instead.
+//
+// KeyByIP returns the IPv4 address unchanged, or the /64 prefix for IPv6.
+func KeyByIP(r *http.Request) (string, error) {
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		ip = r.RemoteAddr
+	}
+	return canonicalizeIP(ip), nil
+}
+
+// Deprecated: WithKeyByIP installs KeyByIP, which keys off r.RemoteAddr — the
+// proxy's address behind a reverse proxy, load balancer, or CDN, and usually
+// the wrong key in production (see KeyByIP). It is not a spoofing issue, but
+// there is no safe default IP source. State your trust model explicitly:
+// install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
+// use LimitBy with KeyFromContext(middleware.GetClientIP) instead.
+func WithKeyByIP() Option {
+	return WithKeyFuncs(KeyByIP)
+}
+
+// canonicalizeIP returns a form of ip suitable for comparison to other IPs.
+// For IPv4 addresses, this is simply the whole string.
+// For IPv6 addresses, this is the /64 prefix.
+//
+// Only used by the deprecated KeyByIP / KeyByRealIP above. The supported
+// client-IP path (chi's middleware.ClientIPFrom* + KeyFromContext) canonicalizes
+// the IP upstream, so httprate no longer needs this for new code.
+func canonicalizeIP(ip string) string {
+	isIPv6 := false
+	// This is how net.ParseIP decides if an address is IPv6
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/net/ip.go;l=704
+	for i := 0; !isIPv6 && i < len(ip); i++ {
+		switch ip[i] {
+		case '.':
+			// IPv4
+			return ip
+		case ':':
+			// IPv6
+			isIPv6 = true
+			break
+		}
+	}
+	if !isIPv6 {
+		// Not an IP address at all
+		return ip
+	}
+
+	ipv6 := net.ParseIP(ip)
+	if ipv6 == nil {
+		return ip
+	}
+
+	return ipv6.Mask(net.CIDRMask(64, 128)).String()
 }

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,96 @@
+package httprate
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// This file collects the deprecated public surface in one place. These are kept
+// for backward compatibility and still compile/behave as before, but new code
+// should migrate to the replacements called out in each doc comment. httprate
+// has not reached a stable v1, so a future major release may remove them.
+
+// Deprecated: Use LimitBy(requestLimit, windowLength, keyFn, options...) instead,
+// which makes the rate-limit key an explicit, required argument rather than an
+// optional WithKeyFuncs. Pass the key function directly (e.g. httprate.KeyByIP),
+// or httprate.Key("*") for a single global bucket. The remaining options
+// (WithLimitCounter, WithLimitHandler, WithResponseHeaders, ...) carry over
+// unchanged as LimitBy's trailing variadic.
+func Limit(requestLimit int, windowLength time.Duration, options ...Option) func(next http.Handler) http.Handler {
+	// Key("*") is the default key; any WithKeyFuncs in options overrides it.
+	return LimitBy(requestLimit, windowLength, Key("*"), options...)
+}
+
+// Deprecated: Use LimitBy(requestLimit, windowLength, Key("*")) instead — a
+// single global rate-limit bucket keyed by a constant. (LimitAll already keys
+// every request by "*" under the hood; this just makes that explicit.)
+func LimitAll(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
+	return LimitBy(requestLimit, windowLength, Key("*"))
+}
+
+// Deprecated: Use LimitBy(requestLimit, windowLength, KeyByIP) instead. This is
+// an ergonomic rename with identical behavior, not a security fix.
+func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
+	return LimitBy(requestLimit, windowLength, KeyByIP)
+}
+
+// Deprecated: LimitByRealIP is built on the spoofable KeyByRealIP and lets a
+// remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
+// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
+// middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
+// (chi v5.3.0+) and use LimitBy with KeyFromContext instead:
+//
+//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+//	r.Use(httprate.LimitBy(requestLimit, windowLength, httprate.KeyFromContext(middleware.GetClientIP)))
+func LimitByRealIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
+	return LimitBy(requestLimit, windowLength, KeyByRealIP)
+}
+
+// Deprecated: KeyByRealIP trusts the client-supplied True-Client-IP,
+// X-Real-IP, and X-Forwarded-For headers without verifying any proxy chain, so
+// a remote attacker can forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
+// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
+// middleware.RealIP. On a rate-limiter this is two-sided: an attacker can evade
+// the limit by rotating the spoofed header (unbounded buckets) or lock a victim
+// out by pinning the header to the victim's IP (exhausting their bucket).
+//
+// Install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
+// use KeyFromContext(middleware.GetClientIP) instead:
+//
+//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+func KeyByRealIP(r *http.Request) (string, error) {
+	var ip string
+
+	if tcip := r.Header.Get("True-Client-IP"); tcip != "" {
+		ip = tcip
+	} else if xrip := r.Header.Get("X-Real-IP"); xrip != "" {
+		ip = xrip
+	} else if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		i := strings.Index(xff, ", ")
+		if i == -1 {
+			i = len(xff)
+		}
+		ip = xff[:i]
+	} else {
+		var err error
+		ip, _, err = net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+	}
+
+	return canonicalizeIP(ip), nil
+}
+
+// Deprecated: WithKeyByRealIP installs the spoofable KeyByRealIP and lets a
+// remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
+// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
+// middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
+// (chi v5.3.0+) and use LimitBy with KeyFromContext(middleware.GetClientIP)
+// instead.
+func WithKeyByRealIP() Option {
+	return WithKeyFuncs(KeyByRealIP)
+}

--- a/httprate.go
+++ b/httprate.go
@@ -24,10 +24,10 @@ func Limit(requestLimit int, windowLength time.Duration, options ...Option) func
 //	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
 //	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
 //
-// Use ComposeKeys to rate-limit by more than one dimension at once:
+// Use JoinKeys to rate-limit by more than one dimension at once:
 //
 //	r.Use(httprate.LimitBy(100, time.Minute,
-//		httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
+//		httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
 func LimitBy(requestLimit int, windowLength time.Duration, keyFn KeyFunc, options ...Option) func(next http.Handler) http.Handler {
 	return Limit(requestLimit, windowLength, append([]Option{WithKeyFuncs(keyFn)}, options...)...)
 }
@@ -196,16 +196,16 @@ func WithNoop() Option {
 	return func(rl *RateLimiter) {}
 }
 
-// ComposeKeys concatenates the results of several KeyFuncs into a single key,
-// joined with ":" separators, so they can be passed to LimitBy's positional
-// key slot for multi-dimensional rate-limiting:
+// JoinKeys joins the results of several KeyFuncs into a single key with ":"
+// separators, so they can be passed to LimitBy's positional key slot for
+// multi-dimensional rate-limiting:
 //
 //	r.Use(httprate.LimitBy(100, time.Minute,
-//		httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
+//		httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
 //
 // It is the positional-argument equivalent of WithKeyFuncs. If any component
-// KeyFunc returns an error, the composed key returns that error.
-func ComposeKeys(fns ...KeyFunc) KeyFunc {
+// KeyFunc returns an error, the joined key returns that error.
+func JoinKeys(fns ...KeyFunc) KeyFunc {
 	return composedKeyFunc(fns...)
 }
 

--- a/httprate.go
+++ b/httprate.go
@@ -22,7 +22,7 @@ import (
 // Use JoinKeys to rate-limit by more than one dimension at once:
 //
 //	r.Use(httprate.LimitBy(100, time.Minute,
-//		httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
+//		httprate.JoinKeys(httprate.KeyFromContext(middleware.GetClientIP), httprate.KeyByEndpoint)))
 func LimitBy(requestLimit int, windowLength time.Duration, keyFn KeyFunc, options ...Option) func(next http.Handler) http.Handler {
 	return NewRateLimiter(requestLimit, windowLength, append([]Option{WithKeyFuncs(keyFn)}, options...)...).Handler
 }
@@ -115,7 +115,7 @@ func WithNoop() Option {
 // multi-dimensional rate-limiting:
 //
 //	r.Use(httprate.LimitBy(100, time.Minute,
-//		httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
+//		httprate.JoinKeys(httprate.KeyFromContext(middleware.GetClientIP), httprate.KeyByEndpoint)))
 //
 // It is the positional-argument equivalent of WithKeyFuncs. If any component
 // KeyFunc returns an error, the joined key returns that error.

--- a/httprate.go
+++ b/httprate.go
@@ -1,7 +1,7 @@
 package httprate
 
 import (
-	"context"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -13,16 +13,19 @@ import (
 // key is a required positional argument, so every call site has to state, on
 // purpose, what it rate-limits by.
 //
-// To rate-limit by client IP behind a proxy, pair it with one of chi's
-// middleware.ClientIPFrom* middlewares (chi v5.3.0+) and KeyFromContext:
+// To rate-limit by a trusted client IP behind a proxy, resolve the IP with one
+// of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and read it back
+// in the KeyFunc; CanonicalizeIP buckets IPv6 clients by their /64:
 //
 //	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
-//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+//	r.Use(httprate.LimitBy(100, time.Minute, func(r *http.Request) (string, error) {
+//		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
+//	}))
 //
 // Use JoinKeys to rate-limit by more than one dimension at once:
 //
 //	r.Use(httprate.LimitBy(100, time.Minute,
-//		httprate.JoinKeys(httprate.KeyFromContext(middleware.GetClientIP), httprate.KeyByEndpoint)))
+//		httprate.JoinKeys(clientIPKey, httprate.KeyByEndpoint)))
 func LimitBy(requestLimit int, windowLength time.Duration, keyFn KeyFunc, options ...Option) func(next http.Handler) http.Handler {
 	return NewRateLimiter(requestLimit, windowLength, append([]Option{WithKeyFuncs(keyFn)}, options...)...).Handler
 }
@@ -45,29 +48,54 @@ func Key(key string) func(r *http.Request) (string, error) {
 	}
 }
 
-// KeyFromContext builds a KeyFunc that reads the rate-limit key from the
-// request context using the given extractor. It is the safe, router-agnostic
-// way to rate-limit by a trusted client IP: pair it with chi's
-// middleware.GetClientIP (chi v5.3.0+), which returns the IP resolved by
-// whichever middleware.ClientIPFrom* middleware you installed upstream.
+// CanonicalizeIP normalizes a client IP string for use as a rate-limit key:
+//
+//   - IPv4 addresses are returned unchanged.
+//   - IPv6 addresses are reduced to their /64 prefix. An IPv6 client typically
+//     controls a whole /64 (2^64 addresses via SLAAC), so keying on the full
+//     address would let it rotate within its own /64 to win a fresh bucket per
+//     request and bypass a per-IP limit. Widen/narrow the prefix yourself if your
+//     clients are delegated a larger block (e.g. a /56 or /48).
+//   - Any other string, including "", is returned unchanged.
+//
+// httprate stays router-agnostic, so it does not resolve the client IP for you —
+// pair CanonicalizeIP with whatever does. With chi's middleware.ClientIPFrom*
+// (chi v5.3.0+) and middleware.GetClientIP:
 //
 //	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
-//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+//	r.Use(httprate.LimitBy(100, time.Minute, func(r *http.Request) (string, error) {
+//		return httprate.CanonicalizeIP(middleware.GetClientIP(r.Context())), nil
+//	}))
 //
-// The extractor is generic over func(context.Context) string, so it is not
-// tied to chi — any framework or custom middleware that stashes a value in the
-// request context (tenant ID, API key, user ID, ...) works the same way.
-//
-// WARNING: if the extractor returns an empty string, every request shares a
-// single rate-limit bucket and the limit fires after requestLimit requests
-// system-wide. When using chi's middleware.GetClientIP, make sure exactly one
-// of middleware.ClientIPFromHeader, middleware.ClientIPFromXFF,
-// middleware.ClientIPFromXFFTrustedProxies, or middleware.ClientIPFromRemoteAddr
-// is installed upstream; otherwise GetClientIP returns "" for every request.
-func KeyFromContext(extractor func(ctx context.Context) string) KeyFunc {
-	return func(r *http.Request) (string, error) {
-		return extractor(r.Context()), nil
+// WARNING: if the resolver returns "" (e.g. no ClientIPFrom* middleware is
+// installed upstream), CanonicalizeIP returns "" and every request shares a
+// single global rate-limit bucket. Strictly more restrictive, but a footgun —
+// make sure the client IP is actually resolved upstream.
+func CanonicalizeIP(ip string) string {
+	isIPv6 := false
+	// This is how net.ParseIP decides if an address is IPv6
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/net/ip.go;l=704
+	for i := 0; !isIPv6 && i < len(ip); i++ {
+		switch ip[i] {
+		case '.':
+			// IPv4
+			return ip
+		case ':':
+			// IPv6
+			isIPv6 = true
+		}
 	}
+	if !isIPv6 {
+		// Not an IP address at all
+		return ip
+	}
+
+	ipv6 := net.ParseIP(ip)
+	if ipv6 == nil {
+		return ip
+	}
+
+	return ipv6.Mask(net.CIDRMask(64, 128)).String()
 }
 
 func KeyByEndpoint(r *http.Request) (string, error) {
@@ -115,9 +143,10 @@ func WithNoop() Option {
 // multi-dimensional rate-limiting:
 //
 //	r.Use(httprate.LimitBy(100, time.Minute,
-//		httprate.JoinKeys(httprate.KeyFromContext(middleware.GetClientIP), httprate.KeyByEndpoint)))
+//		httprate.JoinKeys(clientIPKey, httprate.KeyByEndpoint)))
 //
-// It is the positional-argument equivalent of WithKeyFuncs. If any component
+// where clientIPKey is your own client-IP KeyFunc (see LimitBy and
+// CanonicalizeIP). It is the positional-argument equivalent of WithKeyFuncs. If any component
 // KeyFunc returns an error, the joined key returns that error.
 func JoinKeys(fns ...KeyFunc) KeyFunc {
 	return func(r *http.Request) (string, error) {

--- a/httprate.go
+++ b/httprate.go
@@ -1,6 +1,7 @@
 package httprate
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strings"
@@ -9,6 +10,26 @@ import (
 
 func Limit(requestLimit int, windowLength time.Duration, options ...Option) func(next http.Handler) http.Handler {
 	return NewRateLimiter(requestLimit, windowLength, options...).Handler
+}
+
+// LimitBy is the canonical entry point for rate-limiting by an explicit key.
+//
+// It is shorthand for Limit with keyFn installed as the rate-limit key. The
+// key is a required positional argument, so every call site has to state, on
+// purpose, what it rate-limits by.
+//
+// To rate-limit by client IP behind a proxy, pair it with one of chi's
+// middleware.ClientIPFrom* middlewares (chi v5.3.0+) and KeyFromContext:
+//
+//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+//
+// Use ComposeKeys to rate-limit by more than one dimension at once:
+//
+//	r.Use(httprate.LimitBy(100, time.Minute,
+//		httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
+func LimitBy(requestLimit int, windowLength time.Duration, keyFn KeyFunc, options ...Option) func(next http.Handler) http.Handler {
+	return Limit(requestLimit, windowLength, append([]Option{WithKeyFuncs(keyFn)}, options...)...)
 }
 
 type KeyFunc func(r *http.Request) (string, error)
@@ -27,10 +48,20 @@ func LimitAll(requestLimit int, windowLength time.Duration) func(next http.Handl
 	return Limit(requestLimit, windowLength)
 }
 
+// Deprecated: Use LimitBy(requestLimit, windowLength, KeyByIP) instead. This is
+// an ergonomic rename with identical behavior, not a security fix.
 func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
 	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByIP))
 }
 
+// Deprecated: LimitByRealIP is built on the spoofable KeyByRealIP and lets a
+// remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
+// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
+// middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
+// (chi v5.3.0+) and use LimitBy with KeyFromContext instead:
+//
+//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+//	r.Use(httprate.LimitBy(requestLimit, windowLength, httprate.KeyFromContext(middleware.GetClientIP)))
 func LimitByRealIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
 	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByRealIP))
 }
@@ -49,6 +80,44 @@ func KeyByIP(r *http.Request) (string, error) {
 	return canonicalizeIP(ip), nil
 }
 
+// KeyFromContext builds a KeyFunc that reads the rate-limit key from the
+// request context using the given extractor. It is the safe, router-agnostic
+// way to rate-limit by a trusted client IP: pair it with chi's
+// middleware.GetClientIP (chi v5.3.0+), which returns the IP resolved by
+// whichever middleware.ClientIPFrom* middleware you installed upstream.
+//
+//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
+//
+// The extractor is generic over func(context.Context) string, so it is not
+// tied to chi — any framework or custom middleware that stashes a value in the
+// request context (tenant ID, API key, user ID, ...) works the same way.
+//
+// WARNING: if the extractor returns an empty string, every request shares a
+// single rate-limit bucket and the limit fires after requestLimit requests
+// system-wide. When using chi's middleware.GetClientIP, make sure exactly one
+// of middleware.ClientIPFromHeader, middleware.ClientIPFromXFF,
+// middleware.ClientIPFromXFFTrustedProxies, or middleware.ClientIPFromRemoteAddr
+// is installed upstream; otherwise GetClientIP returns "" for every request.
+func KeyFromContext(extractor func(ctx context.Context) string) KeyFunc {
+	return func(r *http.Request) (string, error) {
+		return extractor(r.Context()), nil
+	}
+}
+
+// Deprecated: KeyByRealIP trusts the client-supplied True-Client-IP,
+// X-Real-IP, and X-Forwarded-For headers without verifying any proxy chain, so
+// a remote attacker can forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
+// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
+// middleware.RealIP. On a rate-limiter this is two-sided: an attacker can evade
+// the limit by rotating the spoofed header (unbounded buckets) or lock a victim
+// out by pinning the header to the victim's IP (exhausting their bucket).
+//
+// Install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
+// use KeyFromContext(middleware.GetClientIP) instead:
+//
+//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
+//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
 func KeyByRealIP(r *http.Request) (string, error) {
 	var ip string
 
@@ -89,6 +158,12 @@ func WithKeyByIP() Option {
 	return WithKeyFuncs(KeyByIP)
 }
 
+// Deprecated: WithKeyByRealIP installs the spoofable KeyByRealIP and lets a
+// remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
+// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
+// middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
+// (chi v5.3.0+) and use LimitBy with KeyFromContext(middleware.GetClientIP)
+// instead.
 func WithKeyByRealIP() Option {
 	return WithKeyFuncs(KeyByRealIP)
 }
@@ -119,6 +194,19 @@ func WithResponseHeaders(headers ResponseHeaders) Option {
 
 func WithNoop() Option {
 	return func(rl *RateLimiter) {}
+}
+
+// ComposeKeys concatenates the results of several KeyFuncs into a single key,
+// joined with ":" separators, so they can be passed to LimitBy's positional
+// key slot for multi-dimensional rate-limiting:
+//
+//	r.Use(httprate.LimitBy(100, time.Minute,
+//		httprate.ComposeKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
+//
+// It is the positional-argument equivalent of WithKeyFuncs. If any component
+// KeyFunc returns an error, the composed key returns that error.
+func ComposeKeys(fns ...KeyFunc) KeyFunc {
+	return composedKeyFunc(fns...)
 }
 
 func composedKeyFunc(keyFuncs ...KeyFunc) KeyFunc {

--- a/httprate.go
+++ b/httprate.go
@@ -8,10 +8,6 @@ import (
 	"time"
 )
 
-func Limit(requestLimit int, windowLength time.Duration, options ...Option) func(next http.Handler) http.Handler {
-	return NewRateLimiter(requestLimit, windowLength, options...).Handler
-}
-
 // LimitBy is the canonical entry point for rate-limiting by an explicit key.
 //
 // It is shorthand for Limit with keyFn installed as the rate-limit key. The
@@ -29,7 +25,7 @@ func Limit(requestLimit int, windowLength time.Duration, options ...Option) func
 //	r.Use(httprate.LimitBy(100, time.Minute,
 //		httprate.JoinKeys(httprate.KeyByIP, httprate.KeyByEndpoint)))
 func LimitBy(requestLimit int, windowLength time.Duration, keyFn KeyFunc, options ...Option) func(next http.Handler) http.Handler {
-	return Limit(requestLimit, windowLength, append([]Option{WithKeyFuncs(keyFn)}, options...)...)
+	return NewRateLimiter(requestLimit, windowLength, append([]Option{WithKeyFuncs(keyFn)}, options...)...).Handler
 }
 
 type KeyFunc func(r *http.Request) (string, error)
@@ -42,28 +38,6 @@ type ResponseHeaders struct {
 	Increment  string // Default: X-RateLimit-Increment
 	Reset      string // Default: X-RateLimit-Reset
 	RetryAfter string // Default: Retry-After
-}
-
-func LimitAll(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
-	return Limit(requestLimit, windowLength)
-}
-
-// Deprecated: Use LimitBy(requestLimit, windowLength, KeyByIP) instead. This is
-// an ergonomic rename with identical behavior, not a security fix.
-func LimitByIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
-	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByIP))
-}
-
-// Deprecated: LimitByRealIP is built on the spoofable KeyByRealIP and lets a
-// remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
-// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
-// middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
-// (chi v5.3.0+) and use LimitBy with KeyFromContext instead:
-//
-//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
-//	r.Use(httprate.LimitBy(requestLimit, windowLength, httprate.KeyFromContext(middleware.GetClientIP)))
-func LimitByRealIP(requestLimit int, windowLength time.Duration) func(next http.Handler) http.Handler {
-	return Limit(requestLimit, windowLength, WithKeyFuncs(KeyByRealIP))
 }
 
 func Key(key string) func(r *http.Request) (string, error) {
@@ -105,43 +79,6 @@ func KeyFromContext(extractor func(ctx context.Context) string) KeyFunc {
 	}
 }
 
-// Deprecated: KeyByRealIP trusts the client-supplied True-Client-IP,
-// X-Real-IP, and X-Forwarded-For headers without verifying any proxy chain, so
-// a remote attacker can forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
-// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
-// middleware.RealIP. On a rate-limiter this is two-sided: an attacker can evade
-// the limit by rotating the spoofed header (unbounded buckets) or lock a victim
-// out by pinning the header to the victim's IP (exhausting their bucket).
-//
-// Install one of chi's middleware.ClientIPFrom* middlewares (chi v5.3.0+) and
-// use KeyFromContext(middleware.GetClientIP) instead:
-//
-//	r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
-//	r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
-func KeyByRealIP(r *http.Request) (string, error) {
-	var ip string
-
-	if tcip := r.Header.Get("True-Client-IP"); tcip != "" {
-		ip = tcip
-	} else if xrip := r.Header.Get("X-Real-IP"); xrip != "" {
-		ip = xrip
-	} else if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		i := strings.Index(xff, ", ")
-		if i == -1 {
-			i = len(xff)
-		}
-		ip = xff[:i]
-	} else {
-		var err error
-		ip, _, err = net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			ip = r.RemoteAddr
-		}
-	}
-
-	return canonicalizeIP(ip), nil
-}
-
 func KeyByEndpoint(r *http.Request) (string, error) {
 	return r.URL.Path, nil
 }
@@ -156,16 +93,6 @@ func WithKeyFuncs(keyFuncs ...KeyFunc) Option {
 
 func WithKeyByIP() Option {
 	return WithKeyFuncs(KeyByIP)
-}
-
-// Deprecated: WithKeyByRealIP installs the spoofable KeyByRealIP and lets a
-// remote attacker forge the rate-limit key — see GHSA-9g5q-2w5x-hmxf,
-// GHSA-rjr7-jggh-pgcp, GHSA-3fxj-6jh8-hvhx for the equivalent flaw in chi's
-// middleware.RealIP. Install one of chi's middleware.ClientIPFrom* middlewares
-// (chi v5.3.0+) and use LimitBy with KeyFromContext(middleware.GetClientIP)
-// instead.
-func WithKeyByRealIP() Option {
-	return WithKeyFuncs(KeyByRealIP)
 }
 
 func WithLimitHandler(h http.HandlerFunc) Option {

--- a/httprate.go
+++ b/httprate.go
@@ -2,7 +2,6 @@ package httprate
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -46,14 +45,6 @@ func Key(key string) func(r *http.Request) (string, error) {
 	}
 }
 
-func KeyByIP(r *http.Request) (string, error) {
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		ip = r.RemoteAddr
-	}
-	return canonicalizeIP(ip), nil
-}
-
 // KeyFromContext builds a KeyFunc that reads the rate-limit key from the
 // request context using the given extractor. It is the safe, router-agnostic
 // way to rate-limit by a trusted client IP: pair it with chi's
@@ -86,13 +77,9 @@ func KeyByEndpoint(r *http.Request) (string, error) {
 func WithKeyFuncs(keyFuncs ...KeyFunc) Option {
 	return func(rl *RateLimiter) {
 		if len(keyFuncs) > 0 {
-			rl.keyFn = composedKeyFunc(keyFuncs...)
+			rl.keyFn = JoinKeys(keyFuncs...)
 		}
 	}
-}
-
-func WithKeyByIP() Option {
-	return WithKeyFuncs(KeyByIP)
 }
 
 func WithLimitHandler(h http.HandlerFunc) Option {
@@ -133,14 +120,10 @@ func WithNoop() Option {
 // It is the positional-argument equivalent of WithKeyFuncs. If any component
 // KeyFunc returns an error, the joined key returns that error.
 func JoinKeys(fns ...KeyFunc) KeyFunc {
-	return composedKeyFunc(fns...)
-}
-
-func composedKeyFunc(keyFuncs ...KeyFunc) KeyFunc {
 	return func(r *http.Request) (string, error) {
 		var key strings.Builder
-		for i := 0; i < len(keyFuncs); i++ {
-			k, err := keyFuncs[i](r)
+		for i := 0; i < len(fns); i++ {
+			k, err := fns[i](r)
 			if err != nil {
 				return "", err
 			}
@@ -149,35 +132,4 @@ func composedKeyFunc(keyFuncs ...KeyFunc) KeyFunc {
 		}
 		return key.String(), nil
 	}
-}
-
-// canonicalizeIP returns a form of ip suitable for comparison to other IPs.
-// For IPv4 addresses, this is simply the whole string.
-// For IPv6 addresses, this is the /64 prefix.
-func canonicalizeIP(ip string) string {
-	isIPv6 := false
-	// This is how net.ParseIP decides if an address is IPv6
-	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/net/ip.go;l=704
-	for i := 0; !isIPv6 && i < len(ip); i++ {
-		switch ip[i] {
-		case '.':
-			// IPv4
-			return ip
-		case ':':
-			// IPv6
-			isIPv6 = true
-			break
-		}
-	}
-	if !isIPv6 {
-		// Not an IP address at all
-		return ip
-	}
-
-	ipv6 := net.ParseIP(ip)
-	if ipv6 == nil {
-		return ip
-	}
-
-	return ipv6.Mask(net.CIDRMask(64, 128)).String()
 }

--- a/httprate_test.go
+++ b/httprate_test.go
@@ -2,7 +2,7 @@ package httprate
 
 import "testing"
 
-func Test_canonicalizeIP(t *testing.T) {
+func TestCanonicalizeIP(t *testing.T) {
 	tests := []struct {
 		name string
 		ip   string
@@ -51,8 +51,8 @@ func Test_canonicalizeIP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := canonicalizeIP(tt.ip); got != tt.want {
-				t.Errorf("canonicalizeIP() = %v, want %v", got, tt.want)
+			if got := CanonicalizeIP(tt.ip); got != tt.want {
+				t.Errorf("CanonicalizeIP() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`KeyByRealIP` — and `LimitByRealIP` / `WithKeyByRealIP` built on it — derive the rate-limit key from client-supplied headers (`True-Client-IP`, `X-Real-IP`, `X-Forwarded-For`) with **no proxy-trust check**. A remote attacker can forge the key to either:

- **Evade** the limit — rotate the spoofed header → unbounded buckets, limit defeated; or
- **Lock out a victim** — pin the header to the victim's IP → exhaust their bucket and 429 them out.

This is the same class of flaw fixed in chi's `middleware.RealIP` in v5.3.0 ([GHSA-9g5q-2w5x-hmxf](https://github.com/go-chi/chi/security/advisories/GHSA-9g5q-2w5x-hmxf), [GHSA-rjr7-jggh-pgcp](https://github.com/go-chi/chi/security/advisories/GHSA-rjr7-jggh-pgcp), [GHSA-3fxj-6jh8-hvhx](https://github.com/go-chi/chi/security/advisories/GHSA-3fxj-6jh8-hvhx)).

This PR closes the spoofing hole and modernizes the key API around a single, explicit-trust pattern. All deprecated functions keep compiling (doc-only `// Deprecated:`). httprate has not reached a stable v1, so the deprecated surface may be removed in a future release.

## New (supported) API

- `LimitBy(requestLimit, windowLength, keyFn, opts...)` — canonical entry point; the key is a **required positional argument**, so every call site states what it limits by.
- `KeyFromContext(func(context.Context) string)` — reads the key from the request context. Pairs with chi's `middleware.GetClientIP` (chi v5.3.0+), fed by one of the `middleware.ClientIPFrom*` middlewares. Generic over the extractor, so non-chi frameworks work too.
- `JoinKeys(...KeyFunc)` — `:`-joined multi-dimensional key for `LimitBy` (the positional-arg equivalent of `WithKeyFuncs`).

### Recommended pattern (rate-limit by trusted client IP)

```go
// Pick exactly ONE chi ClientIPFrom* matching your deployment:
r.Use(middleware.ClientIPFromXFF("10.0.0.0/8"))
// Then rate-limit by the trusted client IP:
r.Use(httprate.LimitBy(100, time.Minute, httprate.KeyFromContext(middleware.GetClientIP)))
```

There is no safe default IP source — you state your trust model explicitly. If no `ClientIPFrom*` runs upstream, `GetClientIP` returns `""` and all requests share one global bucket (strictly more restrictive — a footgun, not a security regression).

## Deprecations

**Security (spoofable — the GHSA):**
- `KeyByRealIP`, `WithKeyByRealIP`, `LimitByRealIP`

**Footguns / ergonomics (NOT security):**
- `KeyByIP` / `WithKeyByIP` — key off `r.RemoteAddr`. Not spoofable, but behind a reverse proxy / LB / CDN that's the *proxy's* address, so every client behind a proxy shares one bucket — usually the wrong key in production. Use `middleware.ClientIPFromRemoteAddr` + `KeyFromContext(GetClientIP)` for the directly-exposed case.
- `LimitByIP` — superseded by the above.
- `Limit` → `LimitBy(n, t, keyFn, opts...)`; `LimitAll` → `LimitBy(n, t, Key("*"))`.

The whole deprecated surface is grouped in `deprecated.go`. `Limit`/`LimitAll`/`LimitByIP`/`LimitByRealIP` now delegate to `LimitBy`, mirroring their documented migration.

## Docs / examples / tests / CI

- **README**: security banner with GHSA links; a "Rate limit by client IP behind a proxy" section with the chi `ClientIPFrom*` picker; all examples moved to `LimitBy`.
- **`_example`**: runnable demo of both the directly-exposed and behind-a-proxy patterns; chi bumped `v5.1.0` → `v5.3.0`.
- **Tests**: chi-free unit tests in the root module (`KeyFromContext`, `JoinKeys`, and a `KeyByRealIP` spoof-regression); the chi integration tests that prove the spoof is closed live in the `_example` submodule. The main module's `go.mod` stays **chi-free**; CI runs both modules' tests.

## Test plan

- [x] `go test ./...` passes in the root module.
- [x] `cd _example && go test ./...` passes (chi integration: RemoteAddr happy path, spoofed-XFF fix-in-action, misconfig single-bucket).
- [x] `go vet` + `gofmt` clean in both modules.

## Credits

Cross-references the chi advisories above; thanks to @convto, @rezmoss, and @Saku0512 for the original reports.

Fixes https://github.com/go-chi/httprate/issues/53